### PR TITLE
ci(publish): only build amd64 for now

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,9 +15,6 @@ jobs:
         with:
           fetch-depth: 1
       
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       
@@ -33,7 +30,7 @@ jobs:
         with:
           context: .
           target: hyperion-proxy
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             ghcr.io/${{ github.repository }}/hyperion-proxy:latest
@@ -44,7 +41,7 @@ jobs:
         with:
           context: .
           target: tag
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             ghcr.io/${{ github.repository }}/tag:latest


### PR DESCRIPTION
arm64 seems to take too long and GitHub Actions eventually times out.