### PR TITLE
fix(bvh-region): get_closest on empty bvh

### DIFF
--- a/crates/bvh-region/src/query/closest.rs
+++ b/crates/bvh-region/src/query/closest.rs
@@ -59,7 +59,7 @@ impl<T: Debug> Bvh<T> {
                         }));
                     }
                     Node::Leaf(leaf) => {
-                        let (elem, dist2) = leaf
+                        let Some((elem, dist2)) = leaf
                             .iter()
                             .map(|elem| {
                                 let aabb = get_aabb(elem);
@@ -67,7 +67,9 @@ impl<T: Debug> Bvh<T> {
                                 (elem, dist2)
                             })
                             .min_by_key(|(_, dist)| dist.to_bits())
-                            .unwrap();
+                        else {
+                            continue;
+                        };
 
                         if dist2 < min_dist2 {
                             min_dist2 = dist2;

--- a/crates/bvh-region/tests/simple.rs
+++ b/crates/bvh-region/tests/simple.rs
@@ -114,6 +114,16 @@ fn simple() {
     assert_relative_eq!(dist2, 0.0);
 }
 
+#[test]
+fn test_empty_get_closest() {
+    let elements = vec![];
+
+    let target = Vec3::new(0.0, 0.0, 0.0);
+    let bvh = Bvh::build(elements, copied);
+
+    assert_eq!(bvh.get_closest(target, copied), None);
+}
+
 proptest! {
     #[test]
     fn test_get_closest_correctness(


### PR DESCRIPTION
Previously, the code would panic when calling get_closest on an empty bvh. One way to trigger this is to use the /spawn command and then leave the game. This fix makes it return None with an empty bvh.