### PR TITLE
fix(blocks): return void air above height limit

### DIFF
--- a/crates/hyperion/src/simulation/blocks/mod.rs
+++ b/crates/hyperion/src/simulation/blocks/mod.rs
@@ -379,6 +379,11 @@ impl Blocks {
         let y = u32::try_from(position.y - START_Y).unwrap();
         let z = u32::try_from(position.z - chunk_start_block[1]).unwrap();
 
+        if y >= chunk.height() {
+            // This block is above the chunk maximum height
+            return Some(BlockState::VOID_AIR);
+        }
+
         Some(chunk.block_state(x, y, z))
     }
 


### PR DESCRIPTION
Without this, the code would panic. This can be triggered by shooting an arrow directly up.