### PR TITLE
fix: better player movement handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5493,7 +5493,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn",
@@ -6323,7 +6323,7 @@ dependencies = [
 [[package]]
 name = "valence_anvil"
 version = "0.1.0"
-source = "git+https://github.com/andrewgazelka/valence?branch=feat-open#3b8aa5628a5c706459a241b3d17ceca563cc7473"
+source = "git+https://github.com/andrewgazelka/valence?branch=feat-open#7c664716cd1e7b30de4e38cfc0ee8d1ecc7b0bd5"
 dependencies = [
  "bitfield-struct 0.9.5",
  "bitvec",
@@ -6338,7 +6338,7 @@ dependencies = [
 [[package]]
 name = "valence_build_utils"
 version = "0.2.0-alpha.1+mc.1.20.1"
-source = "git+https://github.com/andrewgazelka/valence?branch=feat-open#3b8aa5628a5c706459a241b3d17ceca563cc7473"
+source = "git+https://github.com/andrewgazelka/valence?branch=feat-open#7c664716cd1e7b30de4e38cfc0ee8d1ecc7b0bd5"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -6348,7 +6348,7 @@ dependencies = [
 [[package]]
 name = "valence_entity"
 version = "0.2.0-alpha.1+mc.1.20.1"
-source = "git+https://github.com/andrewgazelka/valence?branch=feat-open#3b8aa5628a5c706459a241b3d17ceca563cc7473"
+source = "git+https://github.com/andrewgazelka/valence?branch=feat-open#7c664716cd1e7b30de4e38cfc0ee8d1ecc7b0bd5"
 dependencies = [
  "anyhow",
  "bevy_app",
@@ -6377,7 +6377,7 @@ dependencies = [
 [[package]]
 name = "valence_generated"
 version = "0.2.0-alpha.1+mc.1.20.1"
-source = "git+https://github.com/andrewgazelka/valence?branch=feat-open#3b8aa5628a5c706459a241b3d17ceca563cc7473"
+source = "git+https://github.com/andrewgazelka/valence?branch=feat-open#7c664716cd1e7b30de4e38cfc0ee8d1ecc7b0bd5"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -6394,7 +6394,7 @@ dependencies = [
 [[package]]
 name = "valence_ident"
 version = "0.2.0-alpha.1+mc.1.20.1"
-source = "git+https://github.com/andrewgazelka/valence?branch=feat-open#3b8aa5628a5c706459a241b3d17ceca563cc7473"
+source = "git+https://github.com/andrewgazelka/valence?branch=feat-open#7c664716cd1e7b30de4e38cfc0ee8d1ecc7b0bd5"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
@@ -6404,7 +6404,7 @@ dependencies = [
 [[package]]
 name = "valence_ident_macros"
 version = "0.2.0-alpha.1+mc.1.20.1"
-source = "git+https://github.com/andrewgazelka/valence?branch=feat-open#3b8aa5628a5c706459a241b3d17ceca563cc7473"
+source = "git+https://github.com/andrewgazelka/valence?branch=feat-open#7c664716cd1e7b30de4e38cfc0ee8d1ecc7b0bd5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6414,7 +6414,7 @@ dependencies = [
 [[package]]
 name = "valence_math"
 version = "0.2.0-alpha.1+mc.1.20.1"
-source = "git+https://github.com/andrewgazelka/valence?branch=feat-open#3b8aa5628a5c706459a241b3d17ceca563cc7473"
+source = "git+https://github.com/andrewgazelka/valence?branch=feat-open#7c664716cd1e7b30de4e38cfc0ee8d1ecc7b0bd5"
 dependencies = [
  "glam",
 ]
@@ -6422,7 +6422,7 @@ dependencies = [
 [[package]]
 name = "valence_nbt"
 version = "0.8.0"
-source = "git+https://github.com/andrewgazelka/valence?branch=feat-open#3b8aa5628a5c706459a241b3d17ceca563cc7473"
+source = "git+https://github.com/andrewgazelka/valence?branch=feat-open#7c664716cd1e7b30de4e38cfc0ee8d1ecc7b0bd5"
 dependencies = [
  "byteorder",
  "cesu8",
@@ -6435,7 +6435,7 @@ dependencies = [
 [[package]]
 name = "valence_protocol"
 version = "0.2.0-alpha.1+mc.1.20.1"
-source = "git+https://github.com/andrewgazelka/valence?branch=feat-open#3b8aa5628a5c706459a241b3d17ceca563cc7473"
+source = "git+https://github.com/andrewgazelka/valence?branch=feat-open#7c664716cd1e7b30de4e38cfc0ee8d1ecc7b0bd5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6462,7 +6462,7 @@ dependencies = [
 [[package]]
 name = "valence_protocol_macros"
 version = "0.2.0-alpha.1+mc.1.20.1"
-source = "git+https://github.com/andrewgazelka/valence?branch=feat-open#3b8aa5628a5c706459a241b3d17ceca563cc7473"
+source = "git+https://github.com/andrewgazelka/valence?branch=feat-open#7c664716cd1e7b30de4e38cfc0ee8d1ecc7b0bd5"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -6473,7 +6473,7 @@ dependencies = [
 [[package]]
 name = "valence_registry"
 version = "0.2.0-alpha.1+mc.1.20.1"
-source = "git+https://github.com/andrewgazelka/valence?branch=feat-open#3b8aa5628a5c706459a241b3d17ceca563cc7473"
+source = "git+https://github.com/andrewgazelka/valence?branch=feat-open#7c664716cd1e7b30de4e38cfc0ee8d1ecc7b0bd5"
 dependencies = [
  "anyhow",
  "bevy_app",
@@ -6491,7 +6491,7 @@ dependencies = [
 [[package]]
 name = "valence_server"
 version = "0.2.0-alpha.1+mc.1.20.1"
-source = "git+https://github.com/andrewgazelka/valence?branch=feat-open#3b8aa5628a5c706459a241b3d17ceca563cc7473"
+source = "git+https://github.com/andrewgazelka/valence?branch=feat-open#7c664716cd1e7b30de4e38cfc0ee8d1ecc7b0bd5"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -6519,7 +6519,7 @@ dependencies = [
 [[package]]
 name = "valence_server_common"
 version = "0.2.0-alpha.1+mc.1.20.1"
-source = "git+https://github.com/andrewgazelka/valence?branch=feat-open#3b8aa5628a5c706459a241b3d17ceca563cc7473"
+source = "git+https://github.com/andrewgazelka/valence?branch=feat-open#7c664716cd1e7b30de4e38cfc0ee8d1ecc7b0bd5"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -6532,7 +6532,7 @@ dependencies = [
 [[package]]
 name = "valence_text"
 version = "0.2.0-alpha.1+mc.1.20.1"
-source = "git+https://github.com/andrewgazelka/valence?branch=feat-open#3b8aa5628a5c706459a241b3d17ceca563cc7473"
+source = "git+https://github.com/andrewgazelka/valence?branch=feat-open#7c664716cd1e7b30de4e38cfc0ee8d1ecc7b0bd5"
 dependencies = [
  "serde",
  "serde_json",

--- a/crates/hyperion-respawn/src/lib.rs
+++ b/crates/hyperion-respawn/src/lib.rs
@@ -97,8 +97,8 @@ impl Module for RespawnModule {
 
                             let pkt_abilities = PlayerAbilitiesS2c {
                                 flags: PlayerAbilitiesFlags::default()
-                                    .with_flying(flight.allow)
-                                    .with_allow_flying(flight.is_flying),
+                                    .with_flying(flight.is_flying)
+                                    .with_allow_flying(flight.allow),
                                 flying_speed: flying_speed.speed,
                                 fov_modifier: 0.0,
                             };

--- a/crates/hyperion-respawn/src/lib.rs
+++ b/crates/hyperion-respawn/src/lib.rs
@@ -92,6 +92,7 @@ impl Module for RespawnModule {
                             query
                                 .compose
                                 .broadcast(&pkt_add_player, query.system)
+                                .exclude(*connection)
                                 .send()
                                 .unwrap();
                         },

--- a/crates/hyperion-respawn/src/lib.rs
+++ b/crates/hyperion-respawn/src/lib.rs
@@ -6,7 +6,7 @@ use hyperion::{
         prelude::Module,
     },
     net::{ConnectionId, DataBundle},
-    protocol::{game_mode::OptGameMode, packets::play, ByteAngle, VarInt},
+    protocol::{game_mode::OptGameMode, packets::play, BlockPos, ByteAngle, GlobalPos, VarInt},
     server::{ident, GameMode},
     simulation::{
         event::{ClientStatusCommand, ClientStatusEvent},
@@ -65,7 +65,10 @@ impl Module for RespawnModule {
                                 is_debug: false,
                                 is_flat: false,
                                 copy_metadata: false,
-                                last_death_location: None,
+                                last_death_location: Option::from(GlobalPos {
+                                    dimension_name: ident!("minecraft:overworld").into(),
+                                    position: BlockPos::from(position.as_dvec3()),
+                                }),
                                 portal_cooldown: VarInt::default(),
                             };
 

--- a/crates/hyperion/src/egress/player_join/mod.rs
+++ b/crates/hyperion/src/egress/player_join/mod.rs
@@ -567,6 +567,7 @@ impl Module for PlayerJoinModule {
                         |(uuid, name, position, yaw, pitch, &stream_id)| {
                             let query = &query;
                             let query = &query.0;
+                            entity.set_name(name);
 
                             // if we get an error joining, we should kick the player
                             if let Err(e) = player_join_world(

--- a/crates/hyperion/src/egress/player_join/mod.rs
+++ b/crates/hyperion/src/egress/player_join/mod.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, collections::BTreeSet, ops::Index};
 
 use anyhow::Context;
 use flecs_ecs::prelude::*;
-use glam::Vec3;
+use glam::{DVec3, Vec3};
 use hyperion_crafting::{Action, CraftingRegistry, RecipeBookState};
 use hyperion_utils::EntityExt;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -83,6 +83,9 @@ pub fn player_join_world(
         last_tick_position: **position,
         last_tick_velocity: Vec3::ZERO,
         fall_start_y: position.y,
+        server_velocity: DVec3::ZERO,
+        sprinting: false,
+        was_on_ground: false,
     });
 
     let registry_codec = registry_codec_raw();

--- a/crates/hyperion/src/egress/player_join/mod.rs
+++ b/crates/hyperion/src/egress/player_join/mod.rs
@@ -79,10 +79,10 @@ pub fn player_join_world(
 
     entity.set(MovementTracking {
         received_movement_packets: 0,
+        last_tick_flying: false,
         last_tick_position: **position,
         last_tick_velocity: Vec3::ZERO,
         fall_start_y: position.y,
-        is_flying: false,
     });
 
     let registry_codec = registry_codec_raw();

--- a/crates/hyperion/src/egress/player_join/mod.rs
+++ b/crates/hyperion/src/egress/player_join/mod.rs
@@ -2,6 +2,7 @@ use std::{borrow::Cow, collections::BTreeSet, ops::Index};
 
 use anyhow::Context;
 use flecs_ecs::prelude::*;
+use glam::Vec3;
 use hyperion_crafting::{Action, CraftingRegistry, RecipeBookState};
 use hyperion_utils::EntityExt;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -20,7 +21,7 @@ use valence_registry::{BiomeRegistry, RegistryCodec};
 use valence_server::entity::EntityKind;
 use valence_text::IntoText;
 
-use crate::simulation::{PacketState, Pitch};
+use crate::simulation::{MovementTracking, PacketState, Pitch};
 
 mod list;
 pub use list::*;
@@ -75,6 +76,14 @@ pub fn player_join_world(
     let mut bundle = DataBundle::new(compose, system);
 
     let id = entity.minecraft_id();
+
+    entity.set(MovementTracking {
+        received_movement_packets: 0,
+        last_tick_position: **position,
+        last_tick_velocity: Vec3::ZERO,
+        fall_start_y: position.y,
+        is_flying: false,
+    });
 
     let registry_codec = registry_codec_raw();
     let codec = RegistryCodec::default();

--- a/crates/hyperion/src/egress/player_join/mod.rs
+++ b/crates/hyperion/src/egress/player_join/mod.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, collections::BTreeSet, ops::Index};
 
 use anyhow::Context;
 use flecs_ecs::prelude::*;
-use glam::{DVec3, Vec3};
+use glam::DVec3;
 use hyperion_crafting::{Action, CraftingRegistry, RecipeBookState};
 use hyperion_utils::EntityExt;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -81,7 +81,6 @@ pub fn player_join_world(
         received_movement_packets: 0,
         last_tick_flying: false,
         last_tick_position: **position,
-        last_tick_velocity: Vec3::ZERO,
         fall_start_y: position.y,
         server_velocity: DVec3::ZERO,
         sprinting: false,

--- a/crates/hyperion/src/egress/sync_entity_state.rs
+++ b/crates/hyperion/src/egress/sync_entity_state.rs
@@ -255,17 +255,14 @@ impl Module for EntityStateSyncModule {
                     }
 
                     // Replace 100 by 300 if fall flying (aka elytra)
-                    if position_delta.length_squared()
-                        - tracking.last_tick_velocity.length_squared()
-                        > 100f32 * f32::from(tracking.received_movement_packets)
+                    if f64::from(position_delta.length_squared())
+                        - tracking.server_velocity.length_squared()
+                        > 100f64 * f64::from(tracking.received_movement_packets)
                     {
                         entity.set(PendingTeleportation::new(tracking.last_tick_position));
-                        tracking.last_tick_velocity = Vec3::ZERO;
                         tracking.received_movement_packets = 0;
                         return;
                     }
-
-                    tracking.last_tick_velocity = position_delta;
 
                     world.get::<&mut Blocks>(|blocks| {
                         let grounded = is_grounded(position, blocks);

--- a/crates/hyperion/src/egress/sync_entity_state.rs
+++ b/crates/hyperion/src/egress/sync_entity_state.rs
@@ -197,116 +197,117 @@ impl Module for EntityStateSyncModule {
             &Pitch,
             ?&mut PendingTeleportation,
         )
-            .multi_threaded()
-            .kind::<flecs::pipeline::PreStore>()
-            .each_iter(
-                |it,
-                 row,
-                 (
-                     compose,
-                     prev_position,
-                     prev_yaw,
-                     prev_pitch,
-                     position,
-                     velocity,
-                     yaw,
-                     pitch,
-                     pending_teleport,
-                 )| {
-                    let world = it.system().world();
-                    let system = it.system();
-                    let entity = it.entity(row);
-                    let entity_id = VarInt(entity.minecraft_id());
+        .multi_threaded()
+        .kind::<flecs::pipeline::PreStore>()
+        .each_iter(
+            |it,
+             row,
+             (
+                compose,
+                prev_position,
+                prev_yaw,
+                prev_pitch,
+                position,
+                velocity,
+                yaw,
+                pitch,
+                pending_teleport,
+            )| {
+                let world = it.system().world();
+                let system = it.system();
+                let entity = it.entity(row);
+                let entity_id = VarInt(entity.minecraft_id());
 
-                    if let Some(pending_teleport) = pending_teleport {
-                        if pending_teleport.ttl == 0 {
-                            entity.set::<PendingTeleportation>(PendingTeleportation::new(
-                                pending_teleport.destination,
-                            ));
-                        }
-                        pending_teleport.ttl -= 1;
-                    } else {
-                        let chunk_pos = position.to_chunk();
-    
-                        let position_delta = **position - **prev_position;
-                        let needs_teleport = position_delta.abs().max_element() >= 8.0;
-                        let changed_position = **position != **prev_position;
-    
-                        let look_changed = (**yaw - **prev_yaw).abs() >= 0.01 || (**pitch - **prev_pitch).abs() >= 0.01;
-    
-                        let mut bundle = DataBundle::new(compose, system);
-    
-                        world.get::<&mut Blocks>(|blocks| {
-                            let grounded = is_grounded(position, blocks);
-    
-                            if changed_position && !needs_teleport && look_changed {
-                                let packet = play::RotateAndMoveRelativeS2c {
+                if let Some(pending_teleport) = pending_teleport {
+                    if pending_teleport.ttl == 0 {
+                        entity.set::<PendingTeleportation>(PendingTeleportation::new(
+                            pending_teleport.destination,
+                        ));
+                    }
+                    pending_teleport.ttl -= 1;
+                } else {
+                    let chunk_pos = position.to_chunk();
+
+                    let position_delta = **position - **prev_position;
+                    let needs_teleport = position_delta.abs().max_element() >= 8.0;
+                    let changed_position = **position != **prev_position;
+
+                    let look_changed = (**yaw - **prev_yaw).abs() >= 0.01
+                        || (**pitch - **prev_pitch).abs() >= 0.01;
+
+                    let mut bundle = DataBundle::new(compose, system);
+
+                    world.get::<&mut Blocks>(|blocks| {
+                        let grounded = is_grounded(position, blocks);
+
+                        if changed_position && !needs_teleport && look_changed {
+                            let packet = play::RotateAndMoveRelativeS2c {
+                                entity_id,
+                                #[allow(clippy::cast_possible_truncation)]
+                                delta: (position_delta * 4096.0).to_array().map(|x| x as i16),
+                                yaw: ByteAngle::from_degrees(**yaw),
+                                pitch: ByteAngle::from_degrees(**pitch),
+                                on_ground: grounded,
+                            };
+
+                            bundle.add_packet(&packet).unwrap();
+                        } else {
+                            if changed_position && !needs_teleport {
+                                let packet = play::MoveRelativeS2c {
                                     entity_id,
                                     #[allow(clippy::cast_possible_truncation)]
                                     delta: (position_delta * 4096.0).to_array().map(|x| x as i16),
+                                    on_ground: grounded,
+                                };
+
+                                bundle.add_packet(&packet).unwrap();
+                            }
+
+                            if look_changed {
+                                let packet = play::RotateS2c {
+                                    entity_id,
                                     yaw: ByteAngle::from_degrees(**yaw),
                                     pitch: ByteAngle::from_degrees(**pitch),
                                     on_ground: grounded,
                                 };
-    
-                                bundle.add_packet(&packet).unwrap();
-                            } else {
-                                if changed_position && !needs_teleport {
-                                    let packet = play::MoveRelativeS2c {
-                                        entity_id,
-                                        #[allow(clippy::cast_possible_truncation)]
-                                        delta: (position_delta * 4096.0).to_array().map(|x| x as i16),
-                                        on_ground: grounded,
-                                    };
-    
-                                    bundle.add_packet(&packet).unwrap();
-                                }
-    
-                                if look_changed {
-                                    let packet = play::RotateS2c {
-                                        entity_id,
-                                        yaw: ByteAngle::from_degrees(**yaw),
-                                        pitch: ByteAngle::from_degrees(**pitch),
-                                        on_ground: grounded,
-                                    };
-    
-                                    bundle.add_packet(&packet).unwrap();
-                                }
-                                let packet = play::EntitySetHeadYawS2c {
-                                    entity_id,
-                                    head_yaw: ByteAngle::from_degrees(**yaw),
-                                };
-    
+
                                 bundle.add_packet(&packet).unwrap();
                             }
-    
-                            if needs_teleport {
-                                let packet = play::EntityPositionS2c {
-                                    entity_id,
-                                    position: position.as_dvec3(),
-                                    yaw: ByteAngle::from_degrees(**yaw),
-                                    pitch: ByteAngle::from_degrees(**pitch),
-                                    on_ground: grounded,
-                                };
-    
-                                bundle.add_packet(&packet).unwrap();
-                            }
-                        });
-    
-                        if velocity.0 != Vec3::ZERO {
-                            let packet = play::EntityVelocityUpdateS2c {
+                            let packet = play::EntitySetHeadYawS2c {
                                 entity_id,
-                                velocity: velocity.to_packet_units(),
+                                head_yaw: ByteAngle::from_degrees(**yaw),
                             };
-    
+
                             bundle.add_packet(&packet).unwrap();
-                            velocity.0 = Vec3::ZERO;
                         }
-    
-                        bundle.broadcast_local(chunk_pos).unwrap();
+
+                        if needs_teleport {
+                            let packet = play::EntityPositionS2c {
+                                entity_id,
+                                position: position.as_dvec3(),
+                                yaw: ByteAngle::from_degrees(**yaw),
+                                pitch: ByteAngle::from_degrees(**pitch),
+                                on_ground: grounded,
+                            };
+
+                            bundle.add_packet(&packet).unwrap();
+                        }
+                    });
+
+                    if velocity.0 != Vec3::ZERO {
+                        let packet = play::EntityVelocityUpdateS2c {
+                            entity_id,
+                            velocity: velocity.to_packet_units(),
+                        };
+
+                        bundle.add_packet(&packet).unwrap();
+                        velocity.0 = Vec3::ZERO;
                     }
-                },
-            );
+
+                    bundle.broadcast_local(chunk_pos).unwrap();
+                }
+            },
+        );
 
         system!(
             "update_projectile_positions",

--- a/crates/hyperion/src/egress/sync_entity_state.rs
+++ b/crates/hyperion/src/egress/sync_entity_state.rs
@@ -255,7 +255,8 @@ impl Module for EntityStateSyncModule {
                     }
 
                     // Replace 100 by 300 if fall flying (aka elytra)
-                    if position_delta.length_squared() - tracking.last_tick_velocity.length_squared()
+                    if position_delta.length_squared()
+                        - tracking.last_tick_velocity.length_squared()
                         > 100f32 * f32::from(tracking.received_movement_packets)
                     {
                         entity.set(PendingTeleportation::new(tracking.last_tick_position));

--- a/crates/hyperion/src/egress/sync_entity_state.rs
+++ b/crates/hyperion/src/egress/sync_entity_state.rs
@@ -290,6 +290,7 @@ impl Module for EntityStateSyncModule {
                         };
 
                         bundle.add_packet(&packet).unwrap();
+                        velocity.0 = Vec3::ZERO;
                     }
 
                     bundle.broadcast_local(chunk_pos).unwrap();

--- a/crates/hyperion/src/egress/sync_entity_state.rs
+++ b/crates/hyperion/src/egress/sync_entity_state.rs
@@ -8,7 +8,6 @@ use valence_protocol::{
     ByteAngle, RawBytes, VarInt,
     packets::play::{self},
 };
-use valence_text::IntoText;
 
 use crate::{
     Prev,
@@ -207,7 +206,6 @@ impl Module for EntityStateSyncModule {
             ?&mut PendingTeleportation,
             &mut MovementTracking,
             &Flight,
-            &ConnectionId
         )
         .multi_threaded()
         .kind::<flecs::pipeline::PreStore>()
@@ -226,7 +224,6 @@ impl Module for EntityStateSyncModule {
                 pending_teleport,
                 tracking,
                 flight,
-                connection,
             )| {
                 let world = it.system().world();
                 let system = it.system();

--- a/crates/hyperion/src/simulation/blocks/mod.rs
+++ b/crates/hyperion/src/simulation/blocks/mod.rs
@@ -359,9 +359,15 @@ impl Blocks {
     #[must_use]
     pub fn get_block(&self, position: IVec3) -> Option<BlockState> {
         const START_Y: i32 = -64;
+        const MAX_Y: i32 = 383;
 
+        // Todo should probably return none
         if position.y < START_Y {
             // This block is in the void.
+            return Some(BlockState::VOID_AIR);
+        }
+
+        if position.y > MAX_Y {
             return Some(BlockState::VOID_AIR);
         }
 

--- a/crates/hyperion/src/simulation/event.rs
+++ b/crates/hyperion/src/simulation/event.rs
@@ -1,6 +1,5 @@
 //! Flecs components which are used for events.
 
-use derive_more::Constructor;
 use flecs_ecs::{core::Entity, macros::Component};
 use glam::{IVec3, Vec3};
 use hyperion_utils::{Lifetime, RuntimeLifetime};
@@ -46,12 +45,6 @@ pub struct AttackEntity {
     pub target: Entity,
     /// The damage dealt by the attack. This corresponds to the same unit as [`crate::simulation::metadata::living_entity::Health`].
     pub damage: f32,
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Constructor)]
-pub struct HealthUpdate {
-    pub from: f32,
-    pub to: f32,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/crates/hyperion/src/simulation/event.rs
+++ b/crates/hyperion/src/simulation/event.rs
@@ -181,3 +181,10 @@ pub struct UpdateSelectedSlotEvent {
     pub client: Entity,
     pub slot: u8,
 }
+
+#[derive(Clone, Debug)]
+pub struct HitGroundEvent {
+    pub client: Entity,
+    /// This is at least 3
+    pub fall_distance: f32,
+}

--- a/crates/hyperion/src/simulation/handlers.rs
+++ b/crates/hyperion/src/simulation/handlers.rs
@@ -24,7 +24,12 @@ use valence_protocol::{
 use valence_text::IntoText;
 
 use super::{
-    animation::{self, ActiveAnimation}, block_bounds, blocks::Blocks, event::ClientStatusEvent, inventory::{handle_click_slot, handle_update_selected_slot}, ConfirmBlockSequences, EntitySize, Flight, MovementTracking, PendingTeleportation, Position
+    ConfirmBlockSequences, EntitySize, Flight, MovementTracking, PendingTeleportation, Position,
+    animation::{self, ActiveAnimation},
+    block_bounds,
+    blocks::Blocks,
+    event::ClientStatusEvent,
+    inventory::{handle_click_slot, handle_update_selected_slot},
 };
 use crate::{
     net::{Compose, ConnectionId, decoder::BorrowedPacketFrame},

--- a/crates/hyperion/src/simulation/handlers.rs
+++ b/crates/hyperion/src/simulation/handlers.rs
@@ -83,7 +83,6 @@ fn change_position_or_correct_client(query: &mut PacketSwitchQuery<'_>, proposed
             .id
             .entity_view(query.world)
             .set(PendingTeleportation::new(pose.position));
-        println!("Attempting to correct player's position");
     }
 }
 

--- a/crates/hyperion/src/simulation/handlers.rs
+++ b/crates/hyperion/src/simulation/handlers.rs
@@ -24,7 +24,7 @@ use valence_protocol::{
 use valence_text::IntoText;
 
 use super::{
-    ConfirmBlockSequences, EntitySize, MovementTracking, PendingTeleportation, Position,
+    ConfirmBlockSequences, EntitySize, Flight, MovementTracking, PendingTeleportation, Position,
     animation::{self, ActiveAnimation},
     block_bounds,
     blocks::Blocks,
@@ -602,6 +602,20 @@ pub fn confirm_teleportation(
     Ok(())
 }
 
+pub fn player_abilities(
+    pkt: &play::UpdatePlayerAbilitiesC2s,
+    _: &dyn LifetimeHandle<'_>,
+    query: &mut PacketSwitchQuery<'_>,
+) -> anyhow::Result<()> {
+    let entity = query.id.entity_view(query.world);
+
+    entity.get::<&mut Flight>(|flight| match pkt {
+        play::UpdatePlayerAbilitiesC2s::StopFlying => flight.is_flying = false,
+        play::UpdatePlayerAbilitiesC2s::StartFlying => flight.is_flying = flight.allow,
+    });
+    Ok(())
+}
+
 pub fn add_builtin_handlers(registry: &mut HandlerRegistry) {
     registry.add_handler(Box::new(chat_message));
     registry.add_handler(Box::new(click_slot));
@@ -620,6 +634,7 @@ pub fn add_builtin_handlers(registry: &mut HandlerRegistry) {
     registry.add_handler(Box::new(request_command_completions));
     registry.add_handler(Box::new(update_selected_slot));
     registry.add_handler(Box::new(confirm_teleportation));
+    registry.add_handler(Box::new(player_abilities));
 }
 
 /// # Safety

--- a/crates/hyperion/src/simulation/handlers.rs
+++ b/crates/hyperion/src/simulation/handlers.rs
@@ -572,7 +572,6 @@ pub fn confirm_teleportation(
 
     entity.get::<(Option<&PendingTeleportation>, &mut Position)>(|(pending_teleport, position)| {
         if let Some(pending_teleport) = pending_teleport {
-
             if VarInt(pending_teleport.teleport_id) != pkt.teleport_id {
                 return;
             }

--- a/crates/hyperion/src/simulation/handlers.rs
+++ b/crates/hyperion/src/simulation/handlers.rs
@@ -99,8 +99,11 @@ fn change_position_or_correct_client(
 
                 if tracking.sprinting {
                     let smth = yaw.yaw * 0.017_453_292;
-                    tracking.server_velocity +=
-                        DVec3::new(f64::from(-smth.sin()) * 0.2, 0.0, f64::from(smth.cos()) * 0.2);
+                    tracking.server_velocity += DVec3::new(
+                        f64::from(-smth.sin()) * 0.2,
+                        0.0,
+                        f64::from(smth.cos()) * 0.2,
+                    );
                 }
             }
         });

--- a/crates/hyperion/src/simulation/mod.rs
+++ b/crates/hyperion/src/simulation/mod.rs
@@ -615,7 +615,6 @@ pub struct MovementTracking {
     pub fall_start_y: f32,
     pub last_tick_flying: bool,
     pub last_tick_position: Vec3,
-    pub last_tick_velocity: Vec3,
     pub received_movement_packets: u8,
     pub server_velocity: DVec3,
     pub sprinting: bool,

--- a/crates/hyperion/src/simulation/mod.rs
+++ b/crates/hyperion/src/simulation/mod.rs
@@ -604,6 +604,15 @@ impl FlyingSpeed {
     }
 }
 
+#[derive(Component, Default, Debug, Copy, Clone)]
+pub struct MovementTracking {
+    pub received_movement_packets: u8,
+    pub last_tick_position: Vec3,
+    pub last_tick_velocity: Vec3,
+    pub fall_start_y: f32,
+    pub is_flying: bool,
+}
+
 #[derive(Component)]
 pub struct SimModule;
 
@@ -639,6 +648,7 @@ impl Module for SimModule {
         world.component::<Owner>();
         world.component::<PendingTeleportation>();
         world.component::<FlyingSpeed>();
+        world.component::<MovementTracking>();
 
         world.component::<EntityKind>().meta();
 

--- a/crates/hyperion/src/simulation/mod.rs
+++ b/crates/hyperion/src/simulation/mod.rs
@@ -833,8 +833,8 @@ impl Module for SimModule {
 
             let pkt = PlayerAbilitiesS2c {
                 flags: PlayerAbilitiesFlags::default()
-                    .with_flying(flight.allow)
-                    .with_allow_flying(flight.is_flying),
+                    .with_allow_flying(flight.allow)
+                    .with_flying(flight.is_flying),
                 flying_speed: flying_speed.speed,
                 fov_modifier: 0.0,
             };

--- a/crates/hyperion/src/simulation/mod.rs
+++ b/crates/hyperion/src/simulation/mod.rs
@@ -4,7 +4,7 @@ use bytemuck::{Pod, Zeroable};
 use derive_more::{Constructor, Deref, DerefMut, Display, From};
 use flecs_ecs::prelude::*;
 use geometry::aabb::Aabb;
-use glam::{I16Vec2, IVec3, Quat, Vec3};
+use glam::{DVec3, I16Vec2, IVec3, Quat, Vec3};
 use hyperion_utils::EntityExt;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
@@ -617,6 +617,9 @@ pub struct MovementTracking {
     pub last_tick_position: Vec3,
     pub last_tick_velocity: Vec3,
     pub received_movement_packets: u8,
+    pub server_velocity: DVec3,
+    pub sprinting: bool,
+    pub was_on_ground: bool,
 }
 
 #[derive(Component, Default, Debug, Copy, Clone)]

--- a/crates/hyperion/src/storage/event/queue/mod.rs
+++ b/crates/hyperion/src/storage/event/queue/mod.rs
@@ -64,4 +64,5 @@ define_events! {
     event::DropItemStackEvent,
     event::UpdateSelectedSlotEvent,
     event::StartDestroyBlock,
+    event::HitGroundEvent,
 }

--- a/events/tag/src/lib.rs
+++ b/events/tag/src/lib.rs
@@ -9,7 +9,7 @@ use flecs_ecs::prelude::*;
 use hyperion::{GameServerEndpoint, HyperionCore, simulation::Player};
 use hyperion_clap::hyperion_command::CommandRegistry;
 use hyperion_gui::Gui;
-use module::{block::BlockModule, vanish::VanishModule};
+use module::{block::BlockModule, damage::DamageModule, vanish::VanishModule};
 
 mod module;
 
@@ -83,6 +83,7 @@ impl Module for TagModule {
         world.import::<SkinModule>();
         world.import::<VanishModule>();
         world.import::<hyperion_genmap::GenMapModule>();
+        world.import::<DamageModule>();
 
         world.get::<&mut CommandRegistry>(|registry| {
             command::register(registry, world);

--- a/events/tag/src/module.rs
+++ b/events/tag/src/module.rs
@@ -2,6 +2,7 @@ pub mod attack;
 pub mod block;
 pub mod bow;
 pub mod chat;
+pub mod damage;
 pub mod level;
 pub mod regeneration;
 pub mod spawn;

--- a/events/tag/src/module/attack.rs
+++ b/events/tag/src/module/attack.rs
@@ -571,25 +571,22 @@ fn get_respawn_pos(world: &World, base_pos: &Position) -> DVec3 {
             for y in base_pos.as_i16vec3().y - 15..base_pos.as_i16vec3().y + 15 {
                 for z in base_pos.as_i16vec3().z - 15..base_pos.as_i16vec3().z + 15 {
                     let pos = IVec3::new(i32::from(x), i32::from(y), i32::from(z));
-                    match blocks.get_block(pos) {
-                        Some(state) => {
-                            if !is_valid_spawn_block(pos, state, blocks, &avoid_blocks()) {
-                                continue;
-                            }
-
-                            let block_above1 = blocks.get_block(pos.with_y(pos.y + 1));
-                            let block_above2 = blocks.get_block(pos.with_y(pos.y + 2));
-
-                            if let Some(block_above1) = block_above1
-                                && let Some(block_above2) = block_above2
-                                && block_above1.to_kind() == BlockKind::Air
-                                && block_above2.to_kind() == BlockKind::Air
-                            {
-                                position = pos.with_y(pos.y + 1).as_dvec3();
-                                return;
-                            }
+                    if let Some(state) = blocks.get_block(pos) {
+                        if !is_valid_spawn_block(pos, state, blocks, &avoid_blocks()) {
+                            continue;
                         }
-                        None => continue,
+
+                        let block_above1 = blocks.get_block(pos.with_y(pos.y + 1));
+                        let block_above2 = blocks.get_block(pos.with_y(pos.y + 2));
+
+                        if let Some(block_above1) = block_above1
+                            && let Some(block_above2) = block_above2
+                            && block_above1.to_kind() == BlockKind::Air
+                            && block_above2.to_kind() == BlockKind::Air
+                        {
+                            position = pos.with_y(pos.y + 1).as_dvec3();
+                            return;
+                        }
                     }
                 }
             }

--- a/events/tag/src/module/attack.rs
+++ b/events/tag/src/module/attack.rs
@@ -11,8 +11,7 @@ use flecs_ecs::{
 };
 use glam::IVec3;
 use hyperion::{
-    BlockKind,
-    Prev,
+    BlockKind, Prev,
     net::{
         Compose, ConnectionId, agnostic,
         packets::{BossBarAction, BossBarS2c},
@@ -536,36 +535,34 @@ impl Module for AttackModule {
 
                     let client = client_status.client.entity_view(query.world);
 
-                    client.get::<&Team>(
-                        |team| {
-                            let mut pos_vec = vec![];
+                    client.get::<&Team>(|team| {
+                        let mut pos_vec = vec![];
 
-                            query
-                                .world
-                                .query::<(&Position, &Team)>()
-                                .build()
-                                .each_entity(|candidate, (candidate_pos, candidate_team)| {
-                                    if team != candidate_team || candidate == client {
-                                        return;
-                                    }
-                                    pos_vec.push(*candidate_pos);
-                                });
+                        query
+                            .world
+                            .query::<(&Position, &Team)>()
+                            .build()
+                            .each_entity(|candidate, (candidate_pos, candidate_team)| {
+                                if team != candidate_team || candidate == client {
+                                    return;
+                                }
+                                pos_vec.push(*candidate_pos);
+                            });
 
-                            let respawn_pos = if let Some(random_mate) = fastrand::choice(pos_vec) {
-                                // Spawn the player near a teammate
-                                get_respawn_pos(query.world, &random_mate).as_vec3()
-                            } else {
-                                // There are no other teammates, so spawn the player in a random location
-                                query.world.get::<&AsyncRuntime>(|runtime| {
-                                    query.world.get::<&mut Blocks>(|blocks| {
-                                        find_spawn_position(blocks, runtime, &avoid_blocks())
-                                    })
+                        let respawn_pos = if let Some(random_mate) = fastrand::choice(pos_vec) {
+                            // Spawn the player near a teammate
+                            get_respawn_pos(query.world, &random_mate).as_vec3()
+                        } else {
+                            // There are no other teammates, so spawn the player in a random location
+                            query.world.get::<&AsyncRuntime>(|runtime| {
+                                query.world.get::<&mut Blocks>(|blocks| {
+                                    find_spawn_position(blocks, runtime, &avoid_blocks())
                                 })
-                            };
+                            })
+                        };
 
-                            client.set::<PendingTeleportation>(PendingTeleportation::new(respawn_pos));
-                        },
-                    );
+                        client.set::<PendingTeleportation>(PendingTeleportation::new(respawn_pos));
+                    });
 
                     Ok(())
                 },

--- a/events/tag/src/module/attack.rs
+++ b/events/tag/src/module/attack.rs
@@ -583,16 +583,20 @@ fn get_respawn_pos(world: &World, base_pos: &Position) -> DVec3 {
                     let pos = IVec3::new(i32::from(x), i32::from(y), i32::from(z));
                     match blocks.get_block(pos) {
                         Some(state) => {
-                            if is_valid_spawn_block(pos, state, blocks, &avoid_blocks()) {
-                                let block_above1 = blocks.get_block(pos.with_y(pos.y+1));
-                                let block_above2 = blocks.get_block(pos.with_y(pos.y+2));
+                            if !is_valid_spawn_block(pos, state, blocks, &avoid_blocks()) {
+                                continue;
+                            }
 
-                                if let Some(block_above1) = block_above1 && let Some(block_above2) = block_above2 {
-                                    if block_above1.to_kind() == BlockKind::Air && block_above2.to_kind() == BlockKind::Air  {
-                                        position = pos.with_y(pos.y+1).as_dvec3();
-                                        return;
-                                    }
-                                }
+                            let block_above1 = blocks.get_block(pos.with_y(pos.y + 1));
+                            let block_above2 = blocks.get_block(pos.with_y(pos.y + 2));
+
+                            if let Some(block_above1) = block_above1
+                                && let Some(block_above2) = block_above2
+                                && block_above1.to_kind() == BlockKind::Air
+                                && block_above2.to_kind() == BlockKind::Air
+                            {
+                                position = pos.with_y(pos.y + 1).as_dvec3();
+                                return;
                             }
                         }
                         None => continue,

--- a/events/tag/src/module/attack.rs
+++ b/events/tag/src/module/attack.rs
@@ -199,12 +199,6 @@ impl Module for AttackModule {
 
                                     health.damage(damage_after_protection);
 
-                                    let pkt_health = play::HealthUpdateS2c {
-                                        health: **health,
-                                        food: VarInt(20),
-                                        food_saturation: 5.0
-                                    };
-
                                     let delta_x: f64 = f64::from(target_position.x - origin_pos.x);
                                     let delta_z: f64 = f64::from(target_position.z - origin_pos.z);
 
@@ -231,7 +225,6 @@ impl Module for AttackModule {
                                     .build();
 
                                     compose.unicast(&pkt_hurt, *target_connection, system).unwrap();
-                                    compose.unicast(&pkt_health, *target_connection, system).unwrap();
 
                                     if critical_hit {
                                     let particle_pkt = play::ParticleS2c {

--- a/events/tag/src/module/attack.rs
+++ b/events/tag/src/module/attack.rs
@@ -168,9 +168,10 @@ impl Module for AttackModule {
                                 &PlayerInventory,
                                 &Team,
                                 &mut Pose,
-                                &mut Xp
+                                &mut Xp,
+                                &mut Velocity
                             )>(
-                                |(target_connection, immune_until, health, target_position, target_yaw, stats, target_inventory, target_team, target_pose, target_xp)| {
+                                |(target_connection, immune_until, health, target_position, target_yaw, stats, target_inventory, target_team, target_pose, target_xp, target_velocity)| {
                                     if let Some(immune_until) = immune_until {
                                         if immune_until.tick > current_tick {
                                             return;
@@ -508,19 +509,15 @@ impl Module for AttackModule {
                                     let knockback_xz = 8.0;
                                     let knockback_y = 6.432;
 
-                                    let new_vel = Velocity::new(
+                                    let new_vel = Vec3::new(
                                         dir.x * knockback_xz / 20.0,
                                         knockback_y / 20.0,
                                         dir.z * knockback_xz / 20.0
                                     );
 
-                                    // https://github.com/valence-rs/valence/blob/8f3f84d557dacddd7faddb2ad724185ecee2e482/examples/ctf.rs#L987-L989
-                                    let packet = play::EntityVelocityUpdateS2c {
-                                        entity_id: VarInt(target.minecraft_id()),
-                                        velocity: new_vel.to_packet_units(),
-                                    };
+                                    target_velocity.0 = target_velocity.0+new_vel;
 
-                                    compose.broadcast_local(&packet, target_position.to_chunk(), system).send().unwrap();
+                                    // https://github.com/valence-rs/valence/blob/8f3f84d557dacddd7faddb2ad724185ecee2e482/examples/ctf.rs#L987-L989
                                 },
                             );
                         });

--- a/events/tag/src/module/damage.rs
+++ b/events/tag/src/module/damage.rs
@@ -1,0 +1,75 @@
+use flecs_ecs::{
+    core::{EntityViewGet, QueryBuilderImpl, TermBuilderImpl},
+    macros::{Component, system},
+    prelude::{Module, SystemAPI},
+};
+use hyperion::{
+    net::{Compose, ConnectionId, agnostic},
+    simulation::{Position, event::HitGroundEvent, metadata::living_entity::Health},
+    storage::EventQueue,
+};
+use hyperion_utils::EntityExt;
+use valence_protocol::{VarInt, packets::play};
+use valence_server::ident;
+
+#[derive(Component)]
+pub struct DamageModule {}
+
+impl Module for DamageModule {
+    fn module(world: &flecs_ecs::prelude::World) {
+        system!("apply natural damages", world, &mut EventQueue<HitGroundEvent>($), &Compose($))
+            .each_iter(|it, _, (event_queue, compose)| {
+                let world = it.world();
+                let system = it.system();
+
+                for event in event_queue.drain() {
+                    if event.fall_distance <= 3. {
+                        continue;
+                    }
+
+                    let entity = event.client.entity_view(world);
+                    // TODO account for armor/effects and gamemode
+                    let damage = event.fall_distance.floor() - 3.;
+
+                    if damage <= 0. {
+                        continue;
+                    }
+
+                    entity.get::<(&mut Health, &ConnectionId, &Position)>(
+                        |(health, connection, position)| {
+                            health.damage(damage);
+
+                            let pkt_damage_event = play::EntityDamageS2c {
+                                entity_id: VarInt(entity.minecraft_id()),
+                                source_cause_id: VarInt(0),
+                                source_direct_id: VarInt(0),
+                                source_type_id: VarInt(10), // 10 = fall damage
+                                source_pos: Option::None,
+                            };
+
+                            let sound = agnostic::sound(
+                                if event.fall_distance > 7. {
+                                    ident!("minecraft:entity.player.big_fall")
+                                } else {
+                                    ident!("minecraft:entity.player.small_fall")
+                                },
+                                **position,
+                            )
+                            .volume(1.)
+                            .pitch(1.)
+                            .seed(fastrand::i64(..))
+                            .build();
+
+                            compose
+                                .unicast(&pkt_damage_event, *connection, system)
+                                .unwrap();
+                            compose
+                                .broadcast_local(&sound, position.to_chunk(), system)
+                                .send()
+                                .unwrap();
+                        },
+                    );
+                }
+            });
+    }
+}

--- a/events/tag/src/module/damage.rs
+++ b/events/tag/src/module/damage.rs
@@ -1,5 +1,5 @@
 use flecs_ecs::{
-    core::{EntityViewGet, QueryBuilderImpl, TermBuilderImpl},
+    core::{EntityViewGet, QueryBuilderImpl, TermBuilderImpl, World},
     macros::{Component, system},
     prelude::{Module, SystemAPI},
 };
@@ -16,7 +16,7 @@ use valence_server::ident;
 pub struct DamageModule {}
 
 impl Module for DamageModule {
-    fn module(world: &flecs_ecs::prelude::World) {
+    fn module(world: &World) {
         system!("apply natural damages", world, &mut EventQueue<HitGroundEvent>($), &Compose($))
             .each_iter(|it, _, (event_queue, compose)| {
                 let world = it.world();


### PR DESCRIPTION
This PR aims to standardize player position handling notably teleportations and velocity changes.
Right now every module does its own thing and sends packets directly to the client so it is impossible for the server to keep track of the player's state.
By normalizing the way to change player position/velocity it could allow us to implement better movement verification and better on_ground calculation in the future. 