### PR TITLE
fix: do not multithread ChatMessage processing

### DIFF
--- a/events/tag/src/module/chat.rs
+++ b/events/tag/src/module/chat.rs
@@ -36,7 +36,6 @@ impl Module for ChatModule {
             .add_trait::<(flecs::With, ChatCooldown)>();
 
         system!("handle_chat_messages", world, &mut EventQueue<event::ChatMessage>($), &hyperion::net::Compose($))
-            .multi_threaded()
             .each_iter(move |it: TableIter<'_, false>, _: usize, (event_queue, compose): (&mut EventQueue<event::ChatMessage>, &hyperion::net::Compose)| {
                 let world = it.world();
                 let span = info_span!("handle_chat_messages");


### PR DESCRIPTION
Chat messages must be processed before the packet bump allocator is cleared because they store a reference to the packet data. In other words, we need a happens-before relationship where chat message processing happens before the packet bump allocator is cleared. Disabling multithreaded ChatMessage processing is one way of providing this happens-before relationship, and since processing chat messages is relatively cheap, this should not cause any noticable performance problems.