### PR TITLE
fix: malformed packet crash

### DIFF
--- a/crates/hyperion-proto/src/server_to_proxy.rs
+++ b/crates/hyperion-proto/src/server_to_proxy.rs
@@ -48,8 +48,8 @@ pub struct Unicast<'a> {
 pub struct Flush;
 
 /// The server must be prepared to handle other additional packets with this stream from the proxy after the server
-/// sends [`Shutdown`] until the server receives [`PlayerDisconnect`] because proxy to server packets may already be
-/// in transit.
+/// sends [`Shutdown`] until the server receives [`crate::PlayerDisconnect`] because proxy to server packets may
+/// already be in transit.
 #[derive(Archive, Deserialize, Serialize, Clone, Copy, PartialEq, Debug)]
 pub struct Shutdown {
     pub stream: u64,

--- a/crates/hyperion-proto/src/server_to_proxy.rs
+++ b/crates/hyperion-proto/src/server_to_proxy.rs
@@ -47,6 +47,14 @@ pub struct Unicast<'a> {
 #[rkyv(derive(Debug))]
 pub struct Flush;
 
+/// The server must be prepared to handle other additional packets with this stream from the proxy after the server
+/// sends [`Shutdown`] until the server receives [`PlayerDisconnect`] because proxy to server packets may already be
+/// in transit.
+#[derive(Archive, Deserialize, Serialize, Clone, Copy, PartialEq, Debug)]
+pub struct Shutdown {
+    pub stream: u64,
+}
+
 #[derive(Archive, Deserialize, Serialize, Clone, PartialEq)]
 pub enum ServerToProxyMessage<'a> {
     UpdatePlayerChunkPositions(UpdatePlayerChunkPositions),
@@ -55,4 +63,5 @@ pub enum ServerToProxyMessage<'a> {
     Unicast(Unicast<'a>),
     SetReceiveBroadcasts(SetReceiveBroadcasts),
     Flush(Flush),
+    Shutdown(Shutdown),
 }

--- a/crates/hyperion-proxy/src/cache.rs
+++ b/crates/hyperion-proxy/src/cache.rs
@@ -323,6 +323,9 @@ impl BufferedEgress {
                     egress.handle_broadcast_local(instruction);
                 });
             }
+            ArchivedServerToProxyMessage::Shutdown(pkt) => {
+                self.egress.handle_shutdown(pkt);
+            }
         }
     }
 

--- a/crates/hyperion-proxy/src/data.rs
+++ b/crates/hyperion-proxy/src/data.rs
@@ -40,19 +40,9 @@ impl OrderedBytes {
         data: Bytes::from_static(b""),
         exclusions: None,
     };
-    pub const SHUTDOWN: Self = Self {
-        order: u32::MAX - 1,
-        offset: 0,
-        data: Bytes::from_static(b""),
-        exclusions: None,
-    };
 
     pub const fn is_flush(&self) -> bool {
         self.order == u32::MAX
-    }
-
-    pub const fn is_shutdown(&self) -> bool {
-        self.order == u32::MAX - 1
     }
 
     pub const fn no_order(data: Bytes) -> Self {
@@ -120,8 +110,8 @@ impl PlayerHandle {
     }
 
     pub fn shutdown(&self) {
-        let _ = self.writer.try_send(OrderedBytes::SHUTDOWN);
-        self.writer.close().unwrap();
+        // Ignore error for if the channel is already closed
+        let _ = self.writer.close();
     }
 
     pub fn enable_receive_broadcasts(&self) {
@@ -143,7 +133,7 @@ impl PlayerHandle {
                 bail!("failed to send packet to player, channel is full: {is_full}");
             }
             Err(e) => {
-                self.writer.close().unwrap();
+                self.shutdown();
                 bail!("failed to send packet to player: {e}");
             }
         }

--- a/crates/hyperion-proxy/src/egress.rs
+++ b/crates/hyperion-proxy/src/egress.rs
@@ -194,7 +194,7 @@ impl Egress {
 
         let Some(player) = players.get(&id) else {
             // expected to still happen infrequently
-            debug!("Player not found for id {id:?}");
+            warn!("Player not found for id {id:?}");
             return;
         };
 

--- a/crates/hyperion-proxy/src/player.rs
+++ b/crates/hyperion-proxy/src/player.rs
@@ -115,10 +115,6 @@ pub fn initiate_player_connection(
         let mut packet_writer = PlayerPacketWriter::new(socket_writer, player_id);
 
         while let Ok(outgoing_packet) = incoming_packet_receiver.recv().await {
-            if outgoing_packet.is_shutdown() {
-                return;
-            }
-
             if outgoing_packet.is_flush() {
                 let time_start = std::time::Instant::now();
                 if let Err(e) = packet_writer.flush_pending_packets().await {

--- a/crates/hyperion-proxy/src/player.rs
+++ b/crates/hyperion-proxy/src/player.rs
@@ -175,15 +175,14 @@ pub fn initiate_player_connection(
                 if let Err(e) = server_sender.send(disconnect).await {
                     warn!("failed to send player disconnect to server: {e}");
                 }
-
-                let map_ref = player_registry.pin();
-                map_ref.remove(&player_id);
-
-                let map_ref = player_positions.pin();
-                map_ref.remove(&player_id);
-
             }
         }
+
+        let map_ref = player_registry.pin();
+        map_ref.remove(&player_id);
+
+        let map_ref = player_positions.pin();
+        map_ref.remove(&player_id);
     })
 }
 

--- a/crates/hyperion/src/egress/player_join/mod.rs
+++ b/crates/hyperion/src/egress/player_join/mod.rs
@@ -6,7 +6,7 @@ use glam::DVec3;
 use hyperion_crafting::{Action, CraftingRegistry, RecipeBookState};
 use hyperion_utils::EntityExt;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
-use tracing::{info, instrument};
+use tracing::{info, instrument, warn};
 use valence_protocol::{
     ByteAngle, GameMode, Ident, PacketEncoder, RawBytes, VarInt, Velocity,
     game_mode::OptGameMode,
@@ -29,7 +29,6 @@ pub use list::*;
 use crate::{
     config::Config,
     egress::metadata::show_all,
-    ingress::PendingRemove,
     net::{Compose, ConnectionId, DataBundle},
     simulation::{
         Comms, Name, Position, Uuid, Yaw,
@@ -598,7 +597,8 @@ impl Module for PlayerJoinModule {
                                 crafting_registry,
                                 config,
                             ) {
-                                entity.set(PendingRemove::new(e.to_string()));
+                                warn!("player_join_world error: {e:?}");
+                                compose.io_buf().shutdown(stream_id, world);
                             }
                         },
                     );

--- a/crates/hyperion/src/ingress/mod.rs
+++ b/crates/hyperion/src/ingress/mod.rs
@@ -373,10 +373,10 @@ impl Module for IngressModule {
             world,
             &Uuid,
             &Compose($),
-            &PendingRemove,
         )
         .kind(id::<flecs::pipeline::PostLoad>())
-        .each_iter(move |it, row, (uuid, compose, _pending_remove)| {
+        .with(id::<PendingRemove>())
+        .each_iter(move |it, row, (uuid, compose)| {
             let system = it.system();
             let entity = it.entity(row).expect("row must be in bounds");
             let uuids = &[uuid.0];

--- a/crates/hyperion/src/ingress/mod.rs
+++ b/crates/hyperion/src/ingress/mod.rs
@@ -38,17 +38,17 @@ use crate::{
     util::{TracingExt, mojang::MojangClient},
 };
 
+/// This marks players who have already been disconnected and about to be destructed. This should not be sent to
+/// disconnect a player. Use [`crate::net::IoBuf::shutdown`] instead.
 #[derive(Component, Debug)]
 pub struct PendingRemove {
-    pub reason: String,
+    _private: u8,
 }
 
 impl PendingRemove {
     #[must_use]
-    pub fn new(reason: impl Into<String>) -> Self {
-        Self {
-            reason: reason.into(),
-        }
+    const fn new() -> Self {
+        Self { _private: 0 }
     }
 }
 
@@ -339,9 +339,7 @@ impl Module for IngressModule {
                     error!("failed to get id for disconnect stream {disconnect:?}");
                     continue;
                 };
-                world
-                    .entity_from_id(*id)
-                    .set(PendingRemove::new("disconnected"));
+                world.entity_from_id(*id).set(PendingRemove::new());
             }
         });
 
@@ -375,11 +373,10 @@ impl Module for IngressModule {
             world,
             &Uuid,
             &Compose($),
-            &ConnectionId,
             &PendingRemove,
         )
         .kind(id::<flecs::pipeline::PostLoad>())
-        .each_iter(move |it, row, (uuid, compose, io, pending_remove)| {
+        .each_iter(move |it, row, (uuid, compose, _pending_remove)| {
             let system = it.system();
             let entity = it.entity(row).expect("row must be in bounds");
             let uuids = &[uuid.0];
@@ -401,16 +398,6 @@ impl Module for IngressModule {
 
             if let Err(e) = compose.broadcast(&pkt, system).send() {
                 error!("failed to send player remove packet: {e}");
-            }
-
-            if !pending_remove.reason.is_empty() {
-                let pkt = play::DisconnectS2c {
-                    reason: pending_remove.reason.clone().into_cow_text(),
-                };
-
-                if let Err(e) = compose.unicast_no_compression(&pkt, *io, system) {
-                    error!("failed to send disconnect packet: {e}");
-                }
             }
         });
 
@@ -485,7 +472,7 @@ impl Module for IngressModule {
                         Ok(frame) => frame,
                         Err(e) => {
                             error!("failed to decode packet: {e}");
-                            entity.destruct();
+                            compose.io_buf().shutdown(io_ref, &world);
                             break;
                         }
                     };
@@ -498,9 +485,7 @@ impl Module for IngressModule {
                         PacketState::Handshake => {
                             if process_handshake(login_state, &frame).is_err() {
                                 error!("failed to process handshake");
-
-                                entity.destruct();
-
+                                compose.io_buf().shutdown(io_ref, &world);
                                 break;
                             }
                         }
@@ -509,7 +494,7 @@ impl Module for IngressModule {
                                 process_status(login_state, system, &frame, io_ref, compose)
                             {
                                 error!("failed to process status packet: {e}");
-                                entity.destruct();
+                                compose.io_buf().shutdown(io_ref, &world);
                                 break;
                             }
                         }
@@ -549,7 +534,7 @@ impl Module for IngressModule {
                                     error!("failed to send login disconnect packet: {e}");
                                 }
 
-                                entity.destruct();
+                                compose.io_buf().shutdown(io_ref, &world);
                                 break;
                             }
                         }


### PR DESCRIPTION
When a client sends a malformed packet, the server will crash because it used entity.destruct to disconnect players for malformed packets which leads to an abort because, when the server receives PlayerDisconnect from the proxy, the server will try to set PendingRemove on the already-destructed entity.

This PR fixes these errors on player disconnects.