### PR TITLE
fix(ingress): don't fetch skins for players without uuids

### DIFF
--- a/crates/hyperion/src/ingress/mod.rs
+++ b/crates/hyperion/src/ingress/mod.rs
@@ -130,21 +130,25 @@ fn process_login(
     let skins = comms.skins_tx.clone();
     let id = entity.id();
 
-    tasks.spawn(async move {
-        let skin = match PlayerSkin::from_uuid(uuid, &mojang, &skins_collection).await {
-            Ok(Some(skin)) => skin,
-            Err(e) => {
-                error!("failed to get skin {e}. Using empty skin");
-                PlayerSkin::EMPTY
-            }
-            Ok(None) => {
-                error!("failed to get skin. Using empty skin");
-                PlayerSkin::EMPTY
-            }
-        };
+    if profile_id.is_none() {
+        skins.send((id, PlayerSkin::EMPTY)).unwrap();
+    } else {
+        tasks.spawn(async move {
+            let skin = match PlayerSkin::from_uuid(uuid, &mojang, &skins_collection).await {
+                Ok(Some(skin)) => skin,
+                Err(e) => {
+                    error!("failed to get skin {e}. Using empty skin");
+                    PlayerSkin::EMPTY
+                }
+                Ok(None) => {
+                    error!("failed to get skin. Using empty skin");
+                    PlayerSkin::EMPTY
+                }
+            };
 
-        skins.send((id, skin)).unwrap();
-    });
+            skins.send((id, skin)).unwrap();
+        });
+    }
 
     let pkt = login::LoginSuccessS2c {
         uuid,

--- a/crates/hyperion/src/ingress/mod.rs
+++ b/crates/hyperion/src/ingress/mod.rs
@@ -130,9 +130,7 @@ fn process_login(
     let skins = comms.skins_tx.clone();
     let id = entity.id();
 
-    if profile_id.is_none() {
-        skins.send((id, PlayerSkin::EMPTY)).unwrap();
-    } else {
+    if profile_id.is_some() {
         tasks.spawn(async move {
             let skin = match PlayerSkin::from_uuid(uuid, &mojang, &skins_collection).await {
                 Ok(Some(skin)) => skin,
@@ -148,6 +146,8 @@ fn process_login(
 
             skins.send((id, skin)).unwrap();
         });
+    } else {
+        skins.send((id, PlayerSkin::EMPTY)).unwrap();
     }
 
     let pkt = login::LoginSuccessS2c {


### PR DESCRIPTION
The server can skip fetching the skin in this case because the player does not have a skin.