### PR TITLE
fix: inventory slot bounds check

### DIFF
--- a/crates/hyperion-inventory/src/lib.rs
+++ b/crates/hyperion-inventory/src/lib.rs
@@ -326,10 +326,9 @@ impl Inventory {
         &mut self,
         index: u16,
     ) -> Result<&mut ItemSlot, InventoryAccessError> {
-        match self.slots.get_mut(usize::from(index)) {
-            Some(slot) => Ok(slot),
-            None => Err(InventoryAccessError::InvalidSlot { index }),
-        }
+        self.slots
+            .get_mut(usize::from(index))
+            .ok_or(InventoryAccessError::InvalidSlot { index })
     }
 
     /// Returns remaining [`ItemStack`] if not all of the item was added to the slot

--- a/crates/hyperion-inventory/src/lib.rs
+++ b/crates/hyperion-inventory/src/lib.rs
@@ -326,9 +326,10 @@ impl Inventory {
         &mut self,
         index: u16,
     ) -> Result<&mut ItemSlot, InventoryAccessError> {
-        let index = usize::from(index);
-        let slot = &mut self.slots[index];
-        Ok(slot)
+        match self.slots.get_mut(usize::from(index)) {
+            Some(slot) => Ok(slot),
+            None => Err(InventoryAccessError::InvalidSlot { index }),
+        }
     }
 
     /// Returns remaining [`ItemStack`] if not all of the item was added to the slot


### PR DESCRIPTION
## Summary
- prevent panic when mutating invalid inventory slots

## Testing
- `cargo fmt --all -- --check` *(fails: could not download toolchain)*
- `cargo test --locked --all --no-run` *(fails: could not download toolchain)*