### PR TITLE
fix(ci): disable arm64 build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,14 +9,11 @@ jobs:
   build:
     strategy:
       matrix:
-        arch: [amd64, arm64]
+        arch: [amd64]
         include:
           - arch: amd64
             platform: linux/amd64
             runner: ubuntu-latest
-          - arch: arm64
-            platform: linux/arm64
-            runner: arm-hooray
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -93,7 +90,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: |
             ghcr.io/${{ github.repository }}/hyperion-proxy:latest
             ghcr.io/${{ github.repository }}/hyperion-proxy:${{ github.sha }}
@@ -103,7 +100,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: |
             ghcr.io/${{ github.repository }}/tag:latest
             ghcr.io/${{ github.repository }}/tag:${{ github.sha }}


### PR DESCRIPTION
The arm-hooray runner seems to be missing causing the arm64 workflow to time out. Hyperion does not have architecture-specific code, so the arm64 build is not necessary because the program will likely compile on arm64 if compilation succeeds on other architectures.