### PR TITLE
perf: remove NaN check in Ray::new

### DIFF
--- a/crates/geometry/src/ray.rs
+++ b/crates/geometry/src/ray.rs
@@ -40,7 +40,7 @@ impl Ray {
     #[must_use]
     #[inline]
     pub fn new(origin: Vec3, direction: Vec3) -> Self {
-        let inv_direction = direction.map(f32::recip).map(nan_as_inf);
+        let inv_direction = direction.map(f32::recip);
 
         Self {
             origin,


### PR DESCRIPTION
This isn't needed because the reciprocal of 0 will return inf instead of NaN, so checking for NaN in the reciprocal is not needed. The NaN check is only needed later in Ray::voxel_traversal because 0 * inf = NaN