### PR TITLE
fix(is_grounded): return false on unloaded blocks

### DIFF
--- a/crates/hyperion/src/simulation/handlers.rs
+++ b/crates/hyperion/src/simulation/handlers.rs
@@ -277,8 +277,8 @@ pub fn is_grounded(position: &Vec3, blocks: &Blocks) -> bool {
     // Check if the block at the calculated position is not air
     !blocks
         .get_block(IVec3::new(block_x, block_y, block_z))
-        .unwrap()
-        .is_air()
+        .map(BlockState::is_air)
+        .unwrap_or(false)
 }
 
 fn has_block_collision(position: &Vec3, size: EntitySize, blocks: &Blocks) -> bool {


### PR DESCRIPTION
This returns false when a player is in an unloaded chunk instead of panicking.