### PR TITLE
refactor: add proxy channels and remove ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3852,6 +3852,7 @@ name = "hyperion-proxy"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arrayvec",
  "bvh",
  "bytes",
  "clap",

--- a/README.md
+++ b/README.md
@@ -144,26 +144,21 @@ flowchart TB
 sequenceDiagram
     participant P as Player
     participant PH as Proxy Handler
-    participant SB as Server Buffer
-    participant R as Reorderer
     participant B as Broadcast System
     participant S as Game Server
 
-    Note over P,S: Player → Server Flow (Direct)
+    Note over P,S: Player → Server Flow
     P->>PH: Player Packet
     PH->>S: Forward Immediately
-    
-    Note over P,S: Server → Player Flow (Buffered)
-    S->>SB: Server Packets
-    SB-->>SB: Accumulate Packets
-    S->>SB: Flush Signal
-    SB->>R: Batch Transfer
-    R-->>R: Reorder by Packet ID
-    R->>B: Ordered Packets
-    
+
+    Note over P,S: Server → Player Flow
+    S->>B: Server Packets
+
     Note over B: Broadcasting Decision
     alt Local Broadcast
         B->>P: Send to nearby players (BVH)
+    else Channel Broadcast
+        B->>P: Send to subscribed players
     else Global Broadcast
         B->>P: Send to all players
     else Unicast

--- a/crates/hyperion-proto/src/proxy_to_server.rs
+++ b/crates/hyperion-proto/src/proxy_to_server.rs
@@ -30,8 +30,15 @@ pub enum PlayerDisconnectReason<'a> {
 }
 
 #[derive(Archive, Deserialize, Serialize, Clone, PartialEq, Debug)]
+pub struct RequestSubscribeChannelPackets<'a> {
+    #[rkyv(with = InlineAsBox)]
+    pub channels: &'a [u32],
+}
+
+#[derive(Archive, Deserialize, Serialize, Clone, PartialEq, Debug)]
 pub enum ProxyToServerMessage<'a> {
     PlayerConnect(PlayerConnect),
     PlayerDisconnect(PlayerDisconnect<'a>),
     PlayerPackets(PlayerPackets<'a>),
+    RequestSubscribeChannelPackets(RequestSubscribeChannelPackets<'a>),
 }

--- a/crates/hyperion-proto/src/shared.rs
+++ b/crates/hyperion-proto/src/shared.rs
@@ -23,3 +23,9 @@ impl From<I16Vec2> for ChunkPosition {
         }
     }
 }
+
+impl From<ChunkPosition> for I16Vec2 {
+    fn from(value: ChunkPosition) -> Self {
+        Self::new(value.x, value.z)
+    }
+}

--- a/crates/hyperion-proxy/Cargo.toml
+++ b/crates/hyperion-proxy/Cargo.toml
@@ -1,4 +1,5 @@
 [dependencies]
+arrayvec = { workspace = true }
 colored = { workspace = true }
 kanal = { workspace = true }
 papaya = { workspace = true }

--- a/crates/hyperion-proxy/src/cache.rs
+++ b/crates/hyperion-proxy/src/cache.rs
@@ -1,203 +1,60 @@
-use std::{ops::Range, sync::Arc};
+use std::collections::HashSet;
 
-use bvh::{Bvh, Data, Point};
+use bvh::{Aabb, Bvh, Data, Point};
+use bytes::Bytes;
 use glam::I16Vec2;
-use hyperion_proto::{ArchivedServerToProxyMessage, BroadcastGlobal};
-use more_asserts::debug_assert_le;
-use rustc_hash::FxBuildHasher;
+use hyperion_proto::ArchivedServerToProxyMessage;
+use rustc_hash::FxHashMap;
+use tracing::{debug, error};
 
-use crate::egress::{BroadcastLocalInstruction, Egress};
+use crate::egress::Egress;
 
-/// Represents a node in the exclusion list, containing information about the previous node
-/// and the range of the exclusion.
-#[derive(Default, Copy, Clone)]
-pub struct ExclusionNode {
-    /// Index of the previous node in the exclusion list.
-    pub prev_node_index: u32,
-    /// Start of the exclusion range.
-    pub byte_range_start: u32,
-    /// End of the exclusion range.
-    pub byte_range_end: u32,
-}
-
-impl ExclusionNode {
-    /// A placeholder node used as the initial element in the exclusion list.
-    const PLACEHOLDER: Self = Self {
-        prev_node_index: 0,
-        byte_range_start: 0,
-        byte_range_end: 0,
-    };
-}
-
-/// Manages global exclusions for players.
-pub struct ExclusionsManager {
-    /// List of exclusion nodes.
-    pub nodes: Vec<ExclusionNode>,
-    /// Maps player IDs to their last exclusion node index.
-    pub player_to_last_node: std::collections::HashMap<u64, u32, FxBuildHasher>,
-}
-
-impl std::fmt::Debug for ExclusionsManager {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut debug_map = f.debug_map();
-
-        for (&player_id, &last_node_idx) in &self.player_to_last_node {
-            let mut exclusions = Vec::new();
-            let mut current_idx = last_node_idx;
-
-            while current_idx != 0 {
-                let node = &self.nodes[current_idx as usize];
-                exclusions.push(node.byte_range_start..node.byte_range_end);
-                current_idx = node.prev_node_index;
-            }
-
-            // Reverse so exclusions are in chronological order
-            exclusions.reverse();
-            debug_map.entry(&player_id, &exclusions);
-        }
-
-        debug_map.finish()
-    }
-}
-
-impl Default for ExclusionsManager {
-    fn default() -> Self {
-        Self {
-            nodes: vec![ExclusionNode::PLACEHOLDER],
-            player_to_last_node: std::collections::HashMap::default(),
-        }
-    }
-}
-
-impl ExclusionsManager {
-    /// Takes ownership of the current exclusion data and resets the manager.
-    #[must_use]
-    pub fn take(&mut self) -> Self {
-        std::mem::take(self)
-    }
-
-    /// Returns an iterator over the exclusions for a specific player.
-    pub fn exclusions_for_player(&self, player_id: u64) -> impl Iterator<Item = Range<usize>> + '_ {
-        ExclusionIterator::new(self, player_id)
-    }
-
-    /// Appends a new exclusion range for a player.
-    pub fn append_exclusion(&mut self, player_id: u64, range: Range<usize>) {
-        let range_start = u32::try_from(range.start).expect("Exclusion start is too large");
-        let range_end = u32::try_from(range.end).expect("Exclusion end is too large");
-
-        let prev_node_index = self
-            .player_to_last_node
-            .get(&player_id)
-            .copied()
-            .unwrap_or(0);
-
-        if prev_node_index != 0 {
-            let prev_node = &mut self.nodes[prev_node_index as usize];
-
-            if prev_node.byte_range_end == range_start {
-                // merge
-                prev_node.byte_range_end = range_end;
-                return;
-            }
-        }
-
-        let new_node = ExclusionNode {
-            prev_node_index,
-            byte_range_start: range_start,
-            byte_range_end: range_end,
-        };
-
-        let new_index = self.nodes.len() as u32;
-        self.nodes.push(new_node);
-        self.player_to_last_node.insert(player_id, new_index);
-    }
-}
-
-/// Iterator for traversing exclusions for a specific player.
-struct ExclusionIterator<'a> {
-    exclusions: &'a ExclusionsManager,
-    current_index: u32,
-}
-
-impl<'a> ExclusionIterator<'a> {
-    fn new(exclusions: &'a ExclusionsManager, player_id: u64) -> Self {
-        let start_index = exclusions
-            .player_to_last_node
-            .get(&player_id)
-            .copied()
-            .unwrap_or_default();
-
-        Self {
-            exclusions,
-            current_index: start_index,
-        }
-    }
-}
-
-impl Iterator for ExclusionIterator<'_> {
-    type Item = Range<usize>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.current_index == 0 {
-            return None;
-        }
-
-        let node = self.exclusions.nodes.get(self.current_index as usize)?;
-        let start = usize::try_from(node.byte_range_start).expect("Exclusion start is too large");
-        let end = usize::try_from(node.byte_range_end).expect("Exclusion end is too large");
-
-        self.current_index = node.prev_node_index;
-
-        Some(start..end)
-    }
-}
+/// Maximum chunk distance between a packet's center and a player for a local broadcast to be sent to
+/// that player
+const RADIUS: i16 = 16;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-struct LocalBroadcastData {
-    position: I16Vec2,
-    range_start: usize,
-    range_end: usize,
-    player_id_to_exclude: u64,
+struct Player {
+    stream: u64,
+    chunk_position: I16Vec2,
 }
 
-impl LocalBroadcastData {
-    fn len(&self) -> usize {
-        debug_assert_le!(self.range_start, self.range_end);
-        self.range_end - self.range_start
-    }
-}
-
-impl Point for LocalBroadcastData {
+impl Point for Player {
     fn point(&self) -> I16Vec2 {
-        self.position
+        self.chunk_position
     }
 }
 
-impl Data for LocalBroadcastData {
-    type Context<'a> = &'a Vec<u8>;
-    type Unit = u8;
+impl Data for Player {
+    type Unit = u64;
 
-    fn data<'a: 'c, 'b: 'c, 'c>(&'a self, context: &'b Vec<u8>) -> &'c [Self::Unit] {
-        unsafe { context.get_unchecked(self.range_start..self.range_end) }
+    fn data<'a: 'c, 'b: 'c, 'c>(&'a self, (): Self::Context<'b>) -> &'c [Self::Unit] {
+        std::slice::from_ref(&self.stream)
     }
+}
+
+pub struct Channel {
+    /// List of connection ids that are pending a subscription to this channel
+    pending_connections: HashSet<u64>,
+
+    /// List of connection ids that are currently subscribed to this channel
+    subscribed_connections: HashSet<u64>,
+
+    unsubscribe_packets: Bytes,
+}
+
+#[derive(Default)]
+pub struct ChannelManager {
+    channels: FxHashMap<u32, Channel>,
 }
 
 /// Buffers egress operations for optimized processing.
 pub struct BufferedEgress {
-    /// Buffer for required broadcast data.
-    global_broadcast_buffer: Vec<u8>,
-
-    raw_local_broadcast_data: Vec<u8>,
-    local_broadcast_buffer: Vec<LocalBroadcastData>,
-
-    /// Manages player-specific exclusions.
-    exclusion_manager: ExclusionsManager,
+    /// Manages channels
+    channel_manager: ChannelManager,
     /// Reference to the underlying egress handler.
     egress: Egress,
-    /// Tracks the current broadcast order.
-    current_broadcast_order: Option<u32>,
-    local_flush_counter: u32,
+    player_bvh: Bvh<Vec<u64>>,
 }
 
 impl BufferedEgress {
@@ -205,142 +62,269 @@ impl BufferedEgress {
     #[must_use]
     pub fn new(egress: Egress) -> Self {
         Self {
-            global_broadcast_buffer: Vec::new(),
-            raw_local_broadcast_data: vec![],
-            local_broadcast_buffer: Vec::default(),
-            exclusion_manager: ExclusionsManager::default(),
+            channel_manager: ChannelManager::default(),
             egress,
-            current_broadcast_order: None,
-            local_flush_counter: 0,
+            player_bvh: Bvh::default(),
         }
     }
 
     /// Handles incoming server-to-proxy messages.
     // #[instrument(skip_all)]
+    #[expect(clippy::excessive_nesting)]
     pub fn handle_packet(&mut self, message: &ArchivedServerToProxyMessage<'_>) {
         match message {
-            ArchivedServerToProxyMessage::UpdatePlayerChunkPositions(packet) => {
-                self.egress.handle_update_player_chunk_positions(packet);
+            ArchivedServerToProxyMessage::UpdatePlayerPositions(packet) => {
+                let mut players = Vec::with_capacity(packet.stream.len());
+
+                for (stream, position) in packet.stream.iter().zip(packet.positions.iter()) {
+                    let Ok(stream) = rkyv::deserialize::<u64, !>(stream);
+                    let Ok(position) = rkyv::deserialize::<_, !>(position);
+                    let position = I16Vec2::from(position);
+
+                    players.push(Player {
+                        stream,
+                        chunk_position: position,
+                    });
+                }
+
+                self.player_bvh = Bvh::build(&mut players, ());
+            }
+            ArchivedServerToProxyMessage::AddChannel(packet) => {
+                let unsubscribe_packets = match rkyv::deserialize::<_, rkyv::rancor::Error>(
+                    &packet.unsubscribe_packets,
+                ) {
+                    Ok(data) => data,
+                    Err(e) => {
+                        error!(
+                            "failed to deserialize raw unsubscribe packets from AddChannel: {e}"
+                        );
+                        return;
+                    }
+                };
+                debug!("adding channel {}", u32::from(packet.channel_id));
+
+                let previous_channel =
+                    self.channel_manager
+                        .channels
+                        .insert(packet.channel_id.into(), Channel {
+                            pending_connections: HashSet::new(),
+                            subscribed_connections: HashSet::new(),
+                            unsubscribe_packets: Bytes::from(unsubscribe_packets),
+                        });
+
+                if previous_channel.is_some() {
+                    error!(
+                        "server sent AddChannel for a channel with the same id as an existing \
+                         channel"
+                    );
+                }
+            }
+            ArchivedServerToProxyMessage::UpdateChannelPositions(packet) => {
+                let mut requested_subscriptions = Vec::new();
+                let players = self.egress.player_registry.pin_owned();
+                for update in packet.updates.get() {
+                    let channel_id = update.channel_id.into();
+                    let Some(channel) = self.channel_manager.channels.get_mut(&channel_id) else {
+                        error!(
+                            "server sent UpdateChannelPositions with an invalid channel id \
+                             {channel_id}"
+                        );
+                        continue;
+                    };
+
+                    let Ok(channel_position) = rkyv::deserialize::<_, !>(&update.position);
+                    let channel_position = I16Vec2::from(channel_position);
+
+                    let min = channel_position - I16Vec2::splat(RADIUS);
+                    let max = channel_position + I16Vec2::splat(RADIUS);
+
+                    let aabb = Aabb::new(min, max);
+
+                    let slices = self.player_bvh.get_in(aabb);
+
+                    let mut should_remain_subscribed = HashSet::new();
+
+                    for slice in slices {
+                        let (_, streams) = self.player_bvh.inner();
+
+                        let start = slice.start as usize;
+                        let end = slice.end as usize;
+
+                        let streams = &streams[start..end];
+                        for &stream in streams {
+                            let Some(player) = players.get(&stream) else {
+                                error!("bvh contains invalid stream id {stream}");
+                                continue;
+                            };
+
+                            if !player.can_receive_broadcasts() {
+                                continue;
+                            }
+
+                            // This stream should be subscribed to this channel...
+                            if channel.subscribed_connections.contains(&stream) {
+                                // ... and should remain subscribed to this channel
+                                should_remain_subscribed.insert(stream);
+                            } else {
+                                // ... but it is not currently subscribed
+                                if channel.pending_connections.is_empty() {
+                                    // Request subscribe packets from the server
+                                    requested_subscriptions.push(channel_id);
+                                }
+                                channel.pending_connections.insert(stream);
+                            }
+                        }
+                    }
+
+                    channel.subscribed_connections.retain(|stream| {
+                        let should_remain = should_remain_subscribed.contains(stream);
+
+                        if !should_remain {
+                            // This stream is currently subscribed. It will be sent unsubscribe
+                            // packets and removed from the subscribed connections set
+                            self.egress
+                                .unicast(*stream, channel.unsubscribe_packets.clone());
+                            debug!("unsubscribing player {stream} from channel {channel_id}");
+                        }
+
+                        should_remain
+                    });
+                }
+
+                if !requested_subscriptions.is_empty() {
+                    let request = rkyv::to_bytes::<rkyv::rancor::Error>(
+                        &hyperion_proto::ProxyToServerMessage::RequestSubscribeChannelPackets(
+                            hyperion_proto::RequestSubscribeChannelPackets {
+                                channels: &requested_subscriptions,
+                            },
+                        ),
+                    )
+                    .unwrap();
+                    let server_sender = self.egress.server_sender.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = server_sender.send(request).await {
+                            error!("failed to send request subscribe channel packets: {e}");
+                        }
+                    });
+                }
+            }
+            ArchivedServerToProxyMessage::RemoveChannel(packet) => {
+                debug!("removing channel {}", u32::from(packet.channel_id));
+                let Some(channel) = self
+                    .channel_manager
+                    .channels
+                    .remove(&packet.channel_id.into())
+                else {
+                    error!("server sent RemoveChannel for a channel that does not exist");
+                    return;
+                };
+
+                // Unsubscribe all players
+                for &stream in &channel.subscribed_connections {
+                    self.egress
+                        .unicast(stream, channel.unsubscribe_packets.clone());
+                }
+            }
+            ArchivedServerToProxyMessage::SubscribeChannelPackets(packet) => {
+                let exclude = u64::from(packet.exclude);
+                let channel_id = packet.channel_id.into();
+                let data =
+                    Bytes::from(rkyv::deserialize::<_, rkyv::rancor::Error>(&packet.data).unwrap());
+                let Some(channel) = self.channel_manager.channels.get_mut(&channel_id) else {
+                    error!("server sent SubscribeChannelPackets for a channel that does not exist");
+                    return;
+                };
+
+                for &stream in &channel.pending_connections {
+                    if stream == exclude {
+                        continue;
+                    }
+
+                    debug!("subscribing player {stream} to channel {channel_id}");
+                    self.egress.unicast(stream, data.clone());
+                }
+
+                channel
+                    .subscribed_connections
+                    .extend(channel.pending_connections.iter().copied());
+                channel.pending_connections.clear();
             }
             ArchivedServerToProxyMessage::BroadcastGlobal(packet) => {
-                let Ok(packet_order) = rkyv::deserialize::<u32, !>(&packet.order);
+                let data =
+                    Bytes::from(rkyv::deserialize::<_, rkyv::rancor::Error>(&packet.data).unwrap());
+                let Ok(exclude) = rkyv::deserialize::<u64, !>(&packet.exclude);
 
-                if let Some(order) = self.current_broadcast_order
-                    && order != packet_order
-                {
-                    // send the current broadcasts to all players
-                    self.flush_broadcast(order);
+                let players = self.egress.player_registry.pin_owned();
+
+                for (&stream, player) in &players {
+                    if !player.can_receive_broadcasts() || stream == exclude {
+                        continue;
+                    }
+
+                    self.egress.unicast(stream, data.clone());
                 }
-
-                self.current_broadcast_order = Some(packet_order);
-
-                let current_len = self.global_broadcast_buffer.len();
-                self.global_broadcast_buffer.extend_from_slice(&packet.data);
-
-                let Ok(packet_exclude) = rkyv::deserialize::<u64, !>(&packet.exclude);
-
-                if packet_exclude != 0 {
-                    // we need to exclude a player
-                    let new_len = self.global_broadcast_buffer.len();
-                    self.exclusion_manager
-                        .append_exclusion(packet_exclude, current_len..new_len);
-                }
-
-                // TODO: Consider implementing auto-flush based on buffer size
-                // to optimize cache usage.
             }
             ArchivedServerToProxyMessage::BroadcastLocal(packet) => {
                 let Ok(center_x) = rkyv::deserialize::<i16, !>(&packet.center.x);
                 let Ok(center_z) = rkyv::deserialize::<i16, !>(&packet.center.z);
                 let Ok(player_id_to_exclude) = rkyv::deserialize::<u64, !>(&packet.exclude);
+                let data =
+                    Bytes::from(rkyv::deserialize::<_, rkyv::rancor::Error>(&packet.data).unwrap());
 
                 let position = I16Vec2::new(center_x, center_z);
+                let min = position - I16Vec2::splat(RADIUS);
+                let max = position + I16Vec2::splat(RADIUS);
 
-                let before_len = self.raw_local_broadcast_data.len();
-                self.raw_local_broadcast_data
-                    .extend_from_slice(&packet.data);
-                let after_len = self.raw_local_broadcast_data.len();
+                let aabb = Aabb::new(min, max);
 
-                self.local_broadcast_buffer.push(LocalBroadcastData {
-                    // todo: checked
-                    position,
-                    range_start: before_len,
-                    range_end: after_len,
-                    player_id_to_exclude,
-                });
+                let slices = self.player_bvh.get_in(aabb);
+
+                for slice in slices {
+                    let (_, streams) = self.player_bvh.inner();
+
+                    let start = slice.start as usize;
+                    let end = slice.end as usize;
+
+                    let streams = &streams[start..end];
+                    for &stream in streams {
+                        if stream == player_id_to_exclude {
+                            continue;
+                        }
+
+                        self.egress.unicast(stream, data.clone());
+                    }
+                }
+            }
+            ArchivedServerToProxyMessage::BroadcastChannel(packet) => {
+                let exclude = u64::from(packet.exclude);
+                let data =
+                    Bytes::from(rkyv::deserialize::<_, rkyv::rancor::Error>(&packet.data).unwrap());
+
+                let Some(channel) = self.channel_manager.channels.get(&packet.channel_id.into())
+                else {
+                    error!("server sent BroadcastChannel for a channel that does not exist");
+                    return;
+                };
+
+                for &stream in &channel.subscribed_connections {
+                    if stream == exclude {
+                        continue;
+                    }
+
+                    self.egress.unicast(stream, data.clone());
+                }
             }
             ArchivedServerToProxyMessage::Unicast(unicast) => {
-                self.egress.handle_unicast(unicast);
+                let data = rkyv::deserialize::<_, rkyv::rancor::Error>(&unicast.data).unwrap();
+                self.egress
+                    .unicast(unicast.stream.into(), Bytes::from(data));
             }
             ArchivedServerToProxyMessage::SetReceiveBroadcasts(pkt) => {
                 self.egress.handle_set_receive_broadcasts(pkt);
-            }
-            ArchivedServerToProxyMessage::Flush(_) => {
-                if let Some(order) = self.current_broadcast_order.take() {
-                    self.flush_broadcast(order);
-                }
-
-                self.egress.handle_flush();
-                self.local_flush_counter = 0;
-
-                if self.local_broadcast_buffer.is_empty() {
-                    return;
-                }
-
-                let bvh = Bvh::build(
-                    &mut self.local_broadcast_buffer,
-                    &self.raw_local_broadcast_data,
-                );
-
-                let mut exclusions = ExclusionsManager::default();
-                let mut idx_on = 0;
-
-                for packet in &self.local_broadcast_buffer {
-                    // todo: is there a more idiomatic way to do this?
-                    let packet_len = packet.len();
-                    let range = idx_on..idx_on + packet_len;
-
-                    if packet.player_id_to_exclude != 0 {
-                        exclusions.append_exclusion(packet.player_id_to_exclude, range);
-                    }
-
-                    idx_on += packet_len;
-                }
-
-                self.local_broadcast_buffer.clear();
-                self.raw_local_broadcast_data.clear();
-
-                let egress = self.egress;
-                tokio::spawn(async move {
-                    let bvh = bvh.into_bytes();
-
-                    let instruction = BroadcastLocalInstruction {
-                        order: 0,
-                        bvh: Arc::new(bvh),
-                        exclusions: Arc::new(exclusions),
-                    };
-
-                    egress.handle_broadcast_local(instruction);
-                });
             }
             ArchivedServerToProxyMessage::Shutdown(pkt) => {
                 self.egress.handle_shutdown(pkt);
             }
         }
-    }
-
-    /// Flushes the current broadcast buffer.
-    fn flush_broadcast(&mut self, order: u32) {
-        let data = &self.global_broadcast_buffer;
-        let pkt = BroadcastGlobal {
-            data,
-            exclude: 0,
-            order,
-        };
-
-        let exclusions = self.exclusion_manager.take();
-
-        self.egress.handle_broadcast_global(pkt, exclusions);
-        self.global_broadcast_buffer.clear();
     }
 }

--- a/crates/hyperion-proxy/src/egress.rs
+++ b/crates/hyperion-proxy/src/egress.rs
@@ -1,210 +1,44 @@
-use std::sync::Arc;
-
-use bvh::{Aabb, Bvh};
 use bytes::Bytes;
-use glam::I16Vec2;
-use hyperion_proto::{
-    ArchivedSetReceiveBroadcasts, ArchivedShutdown, ArchivedUnicast,
-    ArchivedUpdatePlayerChunkPositions, ChunkPosition,
-};
+use hyperion_proto::{ArchivedSetReceiveBroadcasts, ArchivedShutdown};
 use rustc_hash::FxBuildHasher;
-use tracing::{Instrument, debug, error, info_span, instrument, warn};
+use tracing::{error, instrument, warn};
 
-use crate::{
-    cache::ExclusionsManager,
-    data::{OrderedBytes, PlayerHandle},
-};
+use crate::{data::PlayerHandle, server_sender::ServerSender};
 
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 pub struct Egress {
     // todo: can we do some type of EntityId and SlotMap
-    player_registry: &'static papaya::HashMap<u64, PlayerHandle, FxBuildHasher>,
-    positions: &'static papaya::HashMap<u64, ChunkPosition, FxBuildHasher>,
-}
-
-pub struct BroadcastLocalInstruction {
-    pub order: u32,
-    pub bvh: Arc<Bvh<Bytes>>,
-    pub exclusions: Arc<ExclusionsManager>,
+    pub(crate) player_registry: &'static papaya::HashMap<u64, PlayerHandle, FxBuildHasher>,
+    pub(crate) server_sender: ServerSender,
 }
 
 impl Egress {
     #[must_use]
     pub const fn new(
         player_registry: &'static papaya::HashMap<u64, PlayerHandle, FxBuildHasher>,
-        positions: &'static papaya::HashMap<u64, ChunkPosition, FxBuildHasher>,
+        server_sender: ServerSender,
     ) -> Self {
         Self {
             player_registry,
-            positions,
+            server_sender,
         }
     }
 
     #[instrument(skip_all)]
-    pub fn handle_update_player_chunk_positions(
-        &mut self,
-        pkt: &ArchivedUpdatePlayerChunkPositions,
-    ) {
-        let positions = self.positions.pin();
-        for (stream, position) in pkt.stream.iter().zip(pkt.positions.iter()) {
-            let Ok(stream) = rkyv::deserialize::<u64, !>(stream);
-
-            // todo: can I just grab the whole thing as Infallible?
-            let Ok(position_x) = rkyv::deserialize::<_, !>(&position.x);
-            let Ok(position_z) = rkyv::deserialize::<_, !>(&position.z);
-
-            let position = ChunkPosition {
-                x: position_x,
-                z: position_z,
-            };
-
-            positions.insert(stream, position);
-        }
-    }
-
-    #[instrument(skip_all)]
-    pub fn handle_broadcast_global(
-        &self,
-        pkt: hyperion_proto::BroadcastGlobal<'_>,
-        exclusions: ExclusionsManager,
-    ) {
-        // todo: why cannot I pin_owned inside the spawn
-        let players = self.player_registry.pin_owned();
-        let data = pkt.data;
-        let data = Bytes::copy_from_slice(data);
-
-        tokio::spawn(
-            async move {
-                let exclusions = Arc::new(exclusions);
-
-                // imo it makes sense to read once... it is a fast loop
-                #[allow(clippy::significant_drop_in_scrutinee)]
-                for (_, player) in &players {
-                    if !player.can_receive_broadcasts() {
-                        continue;
-                    }
-
-                    let to_send =
-                        OrderedBytes::with_exclusions(pkt.order, data.clone(), exclusions.clone());
-
-                    if let Err(e) = player.send(to_send) {
-                        warn!("Failed to send data to player: {:?}", e);
-                        player.shutdown();
-                    }
-                }
-            }
-            .instrument(info_span!("broadcast_global_task")),
-        );
-    }
-
-    #[instrument(skip_all)]
-    pub fn handle_flush(&self) {
-        let players = self.player_registry.pin_owned();
-
-        tokio::spawn(
-            async move {
-                for (_, player) in &players {
-                    if let Err(e) = player.send(OrderedBytes::FLUSH) {
-                        warn!("Failed to send data to player: {:?}", e);
-                        player.shutdown();
-                    }
-                }
-            }
-            .instrument(info_span!("flush_task")),
-        );
-    }
-
-    #[instrument(skip_all)]
-    pub fn handle_broadcast_local(self, instruction: BroadcastLocalInstruction) {
-        let order = instruction.order;
-        let bvh = instruction.bvh;
-        let exclusions = instruction.exclusions;
-
-        let positions = self.positions.pin_owned();
-        // we are spawning because it is rather intensive to call get_in_slices on a bvh
-        // #[allow(clippy::significant_drop_tightening)]
-        tokio::spawn(
-            async move {
-                const RADIUS: i16 = 16;
-
-                let players = self.player_registry.pin();
-
-                for (id, &position) in &positions {
-                    let Some(player) = players.get(id) else {
-                        // expected to still happen infrequently
-                        debug!("Player not found for id {id:?}");
-                        continue;
-                    };
-
-                    if !player.can_receive_broadcasts() {
-                        continue;
-                    }
-
-                    let position = I16Vec2::new(position.x, position.z);
-                    let min = position - I16Vec2::splat(RADIUS);
-                    let max = position + I16Vec2::splat(RADIUS);
-
-                    let aabb = Aabb::new(min, max);
-
-                    let slices = bvh.get_in(aabb);
-
-                    for slice in slices {
-                        let (_, data) = bvh.inner();
-
-                        let start = slice.start as usize;
-                        let end = slice.end as usize;
-
-                        let data = data.slice(start..end);
-
-                        let to_send = OrderedBytes {
-                            order,
-                            offset: slice.start,
-                            data,
-                            exclusions: Some(exclusions.clone()),
-                        };
-
-                        if let Err(e) = player.send(to_send) {
-                            warn!("Failed to send data to player: {:?}", e);
-                            player.shutdown();
-                        }
-                    }
-                }
-            }
-            .instrument(info_span!("broadcast_local_task")),
-        );
-    }
-
-    #[instrument(skip_all)]
-    pub fn handle_unicast(&self, pkt: &ArchivedUnicast<'_>) {
-        let data = &pkt.data;
-        let data = data.to_vec();
-        let data = bytes::Bytes::from(data);
-
-        let Ok(order) = rkyv::deserialize::<u32, !>(&pkt.order);
-
-        let ordered = OrderedBytes {
-            order,
-            data,
-            ..OrderedBytes::DEFAULT
-        };
-
-        let Ok(id) = rkyv::deserialize::<u64, !>(&pkt.stream);
-
+    pub fn unicast(&self, stream: u64, data: Bytes) {
         let players = self.player_registry.pin();
 
-        let Some(player) = players.get(&id) else {
+        let Some(player) = players.get(&stream) else {
             // expected to still happen infrequently
-            warn!("Player not found for id {id:?}");
+            warn!("Player not found for id {stream:?}");
             return;
         };
 
         // todo: handle error; kick player if cannot send (buffer full)
-        if let Err(e) = player.send(ordered) {
+        if let Err(e) = player.send(data) {
             warn!("Failed to send data to player: {:?}", e);
             player.shutdown();
         }
-
-        drop(players);
     }
 
     #[instrument(skip_all)]

--- a/crates/hyperion-proxy/src/lib.rs
+++ b/crates/hyperion-proxy/src/lib.rs
@@ -20,7 +20,7 @@ use std::fmt::Debug;
 
 use anyhow::Context;
 use colored::Colorize;
-use hyperion_proto::{ArchivedServerToProxyMessage, ChunkPosition};
+use hyperion_proto::ArchivedServerToProxyMessage;
 use rustc_hash::FxBuildHasher;
 use tokio::{
     io::{AsyncReadExt, BufReader},
@@ -146,11 +146,7 @@ async fn connect_to_server_and_run_proxy(
     let player_registry: &'static papaya::HashMap<u64, PlayerHandle, FxBuildHasher> =
         Box::leak(Box::new(player_registry));
 
-    let player_positions = papaya::HashMap::default();
-    let player_positions: &'static papaya::HashMap<u64, ChunkPosition, FxBuildHasher> =
-        Box::leak(Box::new(player_positions));
-
-    let egress = Egress::new(player_registry, player_positions);
+    let egress = Egress::new(player_registry, server_sender.clone());
 
     let egress = BufferedEgress::new(egress);
 
@@ -217,7 +213,6 @@ async fn connect_to_server_and_run_proxy(
             rx,
             server_sender.clone(),
             player_registry,
-            player_positions,
         );
 
         player_id_on += 1;

--- a/crates/hyperion-proxy/src/main.rs
+++ b/crates/hyperion-proxy/src/main.rs
@@ -83,7 +83,6 @@ fn setup_logging() {
         .with_line_number(false)
         .with_target(false)
         .with_env_filter(EnvFilter::from_default_env())
-        .with_max_level(tracing::Level::INFO)
         .init();
 }
 

--- a/crates/hyperion-utils/src/lib.rs
+++ b/crates/hyperion-utils/src/lib.rs
@@ -11,24 +11,32 @@ pub use cached_save::cached_save;
 pub use prev::{Prev, track_prev};
 
 pub trait EntityExt: Sized {
+    fn id(&self) -> u32;
+    fn from_id(id: u32, world: &World) -> anyhow::Result<Self>;
+
     fn minecraft_id(&self) -> i32;
     fn from_minecraft_id(id: i32, world: &World) -> anyhow::Result<Self>;
 }
 
 impl EntityExt for Entity {
-    fn minecraft_id(&self) -> i32 {
-        let index = self.index();
-        bytemuck::cast(index)
+    fn id(&self) -> u32 {
+        self.index()
     }
 
-    fn from_minecraft_id(id: i32, world: &World) -> anyhow::Result<Self> {
-        let id: u32 = bytemuck::cast(id);
-
+    fn from_id(id: u32, world: &World) -> anyhow::Result<Self> {
         // TODO: According to the docs, this should check if the returned entity is freed
         world
             .entities()
             .resolve_from_id(id)
             .ok_or_else(|| anyhow::anyhow!("minecraft id is invalid"))
+    }
+
+    fn minecraft_id(&self) -> i32 {
+        bytemuck::cast(self.id())
+    }
+
+    fn from_minecraft_id(id: i32, world: &World) -> anyhow::Result<Self> {
+        Self::from_id(bytemuck::cast(id), world)
     }
 }
 

--- a/crates/hyperion/src/egress/channel.rs
+++ b/crates/hyperion/src/egress/channel.rs
@@ -1,0 +1,168 @@
+use bevy::{ecs::world::OnDespawn, prelude::*};
+use hyperion_proto::{ServerToProxyMessage, UpdateChannelPosition, UpdateChannelPositions};
+use hyperion_utils::EntityExt;
+use tracing::error;
+use valence_bytes::CowBytes;
+use valence_protocol::{ByteAngle, RawBytes, VarInt, packets::play};
+
+use crate::{
+    egress::metadata::show_all,
+    net::{Channel, ChannelId, Compose, ConnectionId},
+    simulation::{
+        Pitch, Position, RequestSubscribeChannelPackets, Uuid, Velocity, Yaw,
+        entity_kind::EntityKind,
+        metadata::{MetadataChanges, get_and_clear_metadata},
+    },
+};
+
+fn add_channel(trigger: Trigger<'_, OnAdd, Channel>, compose: Res<'_, Compose>) {
+    let packet = play::EntitiesDestroyS2c {
+        entity_ids: vec![VarInt(trigger.target().minecraft_id())].into(),
+    };
+
+    let packet_buf = compose.io_buf().encode_packet(&packet, &compose).unwrap();
+
+    compose
+        .io_buf()
+        .add_channel(ChannelId::new(trigger.target().id()), &packet_buf);
+}
+
+fn remove_channel(trigger: Trigger<'_, OnDespawn, Channel>, compose: Res<'_, Compose>) {
+    compose
+        .io_buf()
+        .remove_channel(ChannelId::new(trigger.target().id()));
+}
+
+fn update_channel_positions(
+    compose: Res<'_, Compose>,
+    query: Query<'_, '_, (Entity, &Position), With<Channel>>,
+) {
+    let updates = query
+        .iter()
+        .map(|(entity, position)| UpdateChannelPosition {
+            channel_id: entity.id(),
+            position: position.to_chunk().into(),
+        })
+        .collect::<Vec<_>>();
+
+    compose
+        .io_buf()
+        .add_proxy_message(&ServerToProxyMessage::UpdateChannelPositions(
+            UpdateChannelPositions { updates: &updates },
+        ));
+}
+
+fn send_subscribe_channel_packets(
+    mut events: EventReader<'_, '_, RequestSubscribeChannelPackets>,
+    compose: Res<'_, Compose>,
+    query: Query<
+        '_,
+        '_,
+        (
+            Entity,
+            &Uuid,
+            &Position,
+            &Pitch,
+            &Yaw,
+            &Velocity,
+            &EntityKind,
+            Option<&ConnectionId>,
+        ),
+    >,
+    world: &World,
+) {
+    for event in events.read() {
+        let (entity, uuid, position, pitch, yaw, velocity, &entity_kind, connection_id) =
+            match query.get(event.0) {
+                Ok(data) => data,
+                Err(e) => {
+                    error!("failed to send subscribe channel packets: query failed: {e}");
+                    continue;
+                }
+            };
+
+        let mut packet_buf;
+        let minecraft_id = event.0.minecraft_id();
+
+        match entity_kind {
+            EntityKind::Player => {
+                let spawn_packet = play::PlayerSpawnS2c {
+                    entity_id: VarInt(minecraft_id),
+                    player_uuid: **uuid,
+                    position: position.as_dvec3(),
+                    yaw: ByteAngle::from_degrees(**yaw),
+                    pitch: ByteAngle::from_degrees(**pitch),
+                };
+                packet_buf = compose
+                    .io_buf()
+                    .encode_packet(&spawn_packet, &compose)
+                    .unwrap();
+
+                let show_all = show_all(minecraft_id);
+                packet_buf.extend_from_slice(
+                    &compose.io_buf().encode_packet(&show_all, &compose).unwrap(),
+                );
+            }
+            _ => {
+                let velocity = velocity.to_packet_units();
+
+                let spawn_packet = play::EntitySpawnS2c {
+                    entity_id: VarInt(minecraft_id),
+                    object_uuid: uuid.0,
+                    kind: VarInt(entity_kind as i32),
+                    position: position.as_dvec3(),
+                    pitch: ByteAngle::from_degrees(**pitch),
+                    yaw: ByteAngle::from_degrees(**yaw),
+                    head_yaw: ByteAngle::from_degrees(0.0), // todo:
+                    data: VarInt::default(),                // todo:
+                    velocity,
+                };
+                packet_buf = compose
+                    .io_buf()
+                    .encode_packet(&spawn_packet, &compose)
+                    .unwrap();
+
+                let velocity_packet = play::EntityVelocityUpdateS2c {
+                    entity_id: VarInt(minecraft_id),
+                    velocity,
+                };
+                packet_buf.extend_from_slice(
+                    &compose
+                        .io_buf()
+                        .encode_packet(&velocity_packet, &compose)
+                        .unwrap(),
+                );
+            }
+        }
+
+        let mut metadata = MetadataChanges::default();
+        metadata.encode_non_default_components(world.entity(entity));
+
+        if let Some(view) = get_and_clear_metadata(&mut metadata) {
+            let pkt = play::EntityTrackerUpdateS2c {
+                entity_id: VarInt(minecraft_id),
+                tracked_values: RawBytes(CowBytes::Borrowed(&view)),
+            };
+            packet_buf.extend_from_slice(&compose.io_buf().encode_packet(&pkt, &compose).unwrap());
+        }
+
+        compose.io_buf().send_subscribe_channel_packets(
+            event.0.into(),
+            &packet_buf,
+            connection_id.copied(),
+        );
+    }
+}
+
+pub struct ChannelPlugin;
+
+impl Plugin for ChannelPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_observer(add_channel);
+        app.add_observer(remove_channel);
+        app.add_systems(
+            FixedUpdate,
+            (update_channel_positions, send_subscribe_channel_packets),
+        );
+    }
+}

--- a/crates/hyperion/src/ingress/mod.rs
+++ b/crates/hyperion/src/ingress/mod.rs
@@ -153,7 +153,7 @@ pub fn process_login_hello(
 
         let uuid = profile_id.unwrap_or_else(|| offline_uuid(username));
         let uuid_s = format!("{uuid:?}").dimmed();
-        info!("Starting login: {username} {uuid_s}");
+        info!("Starting login: {sender:?} {username} {uuid_s}");
 
         let pkt = LoginSuccessS2c {
             uuid,
@@ -225,10 +225,6 @@ pub fn process_login_hello(
                 entity.insert(skin);
             }
         });
-
-        compose
-            .io_buf()
-            .set_receive_broadcasts(packet.connection_id());
     }
 }
 

--- a/crates/hyperion/src/lib.rs
+++ b/crates/hyperion/src/lib.rs
@@ -122,10 +122,10 @@ pub fn adjust_file_descriptor_limits(recommended_min: u64) -> std::io::Result<()
     Ok(())
 }
 
-#[derive(Event, Debug, Clone, PartialEq, Eq, Hash)]
-pub struct SetEndpoint(SocketAddr);
+#[derive(Resource, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Endpoint(SocketAddr);
 
-impl From<SocketAddr> for SetEndpoint {
+impl From<SocketAddr> for Endpoint {
     fn from(value: SocketAddr) -> Self {
         const DEFAULT_MINECRAFT_PORT: u16 = 25565;
         let port = value.port();
@@ -204,25 +204,26 @@ impl Plugin for HyperionCore {
         app.insert_resource(skins);
         app.insert_resource(MojangClient::new(&runtime, ApiProvider::MAT_DOES_DEV));
         app.insert_resource(Blocks::empty(&runtime));
-        app.insert_resource(runtime);
-        app.add_event::<SetEndpoint>();
         app.add_event::<InitializePlayerPosition>();
-        app.add_observer(set_server_endpoint);
 
         let global = Global::new(shared.clone());
 
-        app.insert_resource(Compose::new(
-            shared.compression_level,
-            global,
-            IoBuf::default(),
-        ));
+        let mut compose = Compose::new(shared.compression_level, global, IoBuf::default());
+
+        app.add_plugins(CommandChannelPlugin);
+        let address = app.world().resource::<Endpoint>();
+        let command_channel = app.world().resource::<CommandChannel>();
+        let egress_comm = init_proxy_comms(&runtime, command_channel.clone(), address.0);
+        compose.io_buf_mut().add_egress_comm(egress_comm);
+
+        app.insert_resource(compose);
+        app.insert_resource(runtime);
         app.insert_resource(CraftingRegistry::default());
         app.insert_resource(StreamLookup::default());
 
         app.add_plugins((
             bevy::time::TimePlugin,
             bevy::app::ScheduleRunnerPlugin::run_loop(Duration::from_millis(10)),
-            CommandChannelPlugin,
             IngressPlugin,
             EgressPlugin,
             SimPlugin,
@@ -234,17 +235,6 @@ impl Plugin for HyperionCore {
         // Minecraft is 20 TPS
         app.insert_resource(Time::<Fixed>::from_hz(20.0));
     }
-}
-
-fn set_server_endpoint(
-    event: Trigger<'_, SetEndpoint>,
-    runtime: Res<'_, runtime::AsyncRuntime>,
-    command_channel: Res<'_, CommandChannel>,
-    mut commands: Commands<'_, '_>,
-) {
-    let address = event.0;
-    let egress_comm = init_proxy_comms(&runtime, command_channel.clone(), address);
-    commands.insert_resource(egress_comm);
 }
 
 /// A scratch buffer for intermediate operations. This will return an empty [`Vec`] when calling [`Scratch::obtain`].

--- a/crates/hyperion/src/simulation/blocks/mod.rs
+++ b/crates/hyperion/src/simulation/blocks/mod.rs
@@ -7,7 +7,7 @@ use bevy::prelude::*;
 use bytes::Bytes;
 use chunk::Column;
 use derive_more::Constructor;
-use geometry::ray::Ray;
+use geometry::{aabb::Aabb, ray::Ray};
 use glam::{I16Vec2, IVec2, IVec3, Vec3};
 use indexmap::IndexMap;
 use loader::{ChunkLoaderHandle, launch_loader};
@@ -126,9 +126,7 @@ impl Blocks {
                 // Check collision with block shapes
                 let collision = block
                     .collision_shapes()
-                    .map(|shape| {
-                        geometry::aabb::Aabb::new(shape.min().as_vec3(), shape.max().as_vec3())
-                    })
+                    .map(|shape| Aabb::new(shape.min().as_vec3(), shape.max().as_vec3()))
                     .map(|shape| shape + origin)
                     .filter_map(|shape| shape.intersect_ray(&ray))
                     .min();

--- a/crates/hyperion/src/simulation/inventory.rs
+++ b/crates/hyperion/src/simulation/inventory.rs
@@ -21,7 +21,7 @@ use super::event;
 use crate::{
     ingress,
     net::{Compose, ConnectionId, DataBundle},
-    simulation::{Position, packet, packet_state},
+    simulation::{packet, packet_state},
 };
 
 pub struct InventoryPlugin;
@@ -147,7 +147,6 @@ fn update_player_inventory(
         (
             Entity,
             &InventoryState,
-            &Position,
             &CursorItem,
             Option<&OpenInventory>,
             &ConnectionId,
@@ -155,7 +154,7 @@ fn update_player_inventory(
     >,
     mut inventory_query: Query<'_, '_, &mut Inventory>,
 ) {
-    for (entity, inv_state, position, cursor_item, open_inventory, &stream_id) in player_query {
+    for (entity, inv_state, cursor_item, open_inventory, &stream_id) in player_query {
         let mut inventory;
         let open_inv;
         if let Some(open_inventory) = open_inventory {
@@ -221,7 +220,7 @@ fn update_player_inventory(
             });
 
             compose
-                .broadcast_local(packet, position.to_chunk())
+                .broadcast_channel(packet, entity.into())
                 .exclude(stream_id)
                 .send()
                 .unwrap();

--- a/events/bedwars/src/command/shoot.rs
+++ b/events/bedwars/src/command/shoot.rs
@@ -2,7 +2,8 @@ use bevy::{ecs::system::SystemState, prelude::*};
 use clap::Parser;
 use hyperion::{
     glam::Vec3,
-    simulation::{Pitch, Position, SpawnEvent, Uuid, Velocity, Yaw, entity_kind::EntityKind},
+    net::Channel,
+    simulation::{Pitch, Position, Uuid, Velocity, Yaw, entity_kind::EntityKind},
 };
 use hyperion_clap::{CommandPermission, MinecraftCommand};
 use tracing::{debug, error};
@@ -57,20 +58,14 @@ impl MinecraftCommand for ShootCommand {
         let entity_id = Uuid::new_v4();
 
         // Create arrow entity with velocity
-        let entity = commands
-            .spawn((
-                EntityKind::Arrow,
-                entity_id,
-                Position::new(spawn_pos.x, spawn_pos.y, spawn_pos.z),
-                Velocity::new(velocity.x, velocity.y, velocity.z),
-                Yaw::new(**yaw),
-                Pitch::new(**pitch),
-            ))
-            .id();
-
-        commands.queue(move |world: &mut World| {
-            let mut events = world.resource_mut::<Events<SpawnEvent>>();
-            events.send(SpawnEvent(entity));
-        });
+        commands.spawn((
+            EntityKind::Arrow,
+            entity_id,
+            Position::new(spawn_pos.x, spawn_pos.y, spawn_pos.z),
+            Velocity::new(velocity.x, velocity.y, velocity.z),
+            Yaw::new(**yaw),
+            Pitch::new(**pitch),
+            Channel,
+        ));
     }
 }

--- a/events/bedwars/src/lib.rs
+++ b/events/bedwars/src/lib.rs
@@ -6,7 +6,7 @@
 use std::net::SocketAddr;
 
 use bevy::prelude::*;
-use hyperion::{HyperionCore, SetEndpoint, simulation::packet_state, spatial::Spatial};
+use hyperion::{Endpoint, HyperionCore, simulation::packet_state, spatial::Spatial};
 use hyperion_proxy_module::SetProxyAddress;
 use valence_text::IntoText;
 
@@ -140,8 +140,8 @@ impl Plugin for BedwarsPlugin {
 pub fn init_game(address: SocketAddr) -> anyhow::Result<()> {
     let mut app = App::new();
 
+    app.insert_resource(Endpoint::from(address));
     app.add_plugins((HyperionCore, BedwarsPlugin));
-    app.world_mut().trigger(SetEndpoint::from(address));
     app.world_mut().trigger(SetProxyAddress {
         server: address.to_string(),
         ..SetProxyAddress::default()

--- a/events/bedwars/src/plugin/attack.rs
+++ b/events/bedwars/src/plugin/attack.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 
 use bevy::prelude::*;
 use derive_more::with_trait::Add;
-use glam::IVec3;
 use hyperion::{
     BlockKind, ingress,
     net::{Compose, ConnectionId, agnostic},


### PR DESCRIPTION
The server is able to create channels and send packets through those channels. The proxy decides which clients are subscribed to those channels and sends subscribe and unsubscribe packets appropriately.

Ordering is also removed. It added extra complexity which is no longer needed since the order was changed to an incremental number. If ordering was kept, the channels feature would be more complex because channel creation and removal would also need to be ordered. With ordering fully removed, systems are expected to use happens-before relationships to determine the order of proxy messages.